### PR TITLE
add package find-java-home as last resort

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -718,6 +718,22 @@
             "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
             "dev": true
         },
+        "find-java-home": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-0.2.0.tgz",
+            "integrity": "sha512-nq5PFOHxE1VSEbdDVkLoA2bAcRnG4ETqJO8ipFq3glIWA52hdWCXYX3emuUyMAQfaqFU4Ea85gqcgaPmOApEPA==",
+            "requires": {
+                "which": "1.0.9",
+                "winreg": "1.2.3"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "1.0.9",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+                    "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
+                }
+            }
+        },
         "findup-sync": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",

--- a/extension/package.json
+++ b/extension/package.json
@@ -72,6 +72,7 @@
         "archiver": "^2.1.0",
         "expand-home-dir": "^0.0.3",
         "file-url": "^2.0.2",
+        "find-java-home": "^0.2.0",
         "glob": "^7.1.1",
         "lodash": "^4.17.4",
         "mkdirp": "^0.5.1",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -6,6 +6,7 @@
 import * as archiver from 'archiver';
 import * as cp from 'child_process';
 import * as expandHomeDir from 'expand-home-dir';
+import * as findJavaHome from 'find-java-home';
 import * as fileUrl from 'file-url';
 import * as fs from 'fs';
 import * as glob from 'glob';
@@ -94,17 +95,18 @@ function checkJavaHome(): Promise<string> {
                 javaHome = process.env['JAVA_HOME'];
             }
         }
-        if (!javaHome) {
-            reject();
+        if (javaHome) {
+            javaHome = expandHomeDir(javaHome);
+            if (pathExists.sync(javaHome) && pathExists.sync(path.resolve(javaHome, 'bin', JAVAC_FILENAME))) {
+                resolve(javaHome);
+            }
         }
-        javaHome = expandHomeDir(javaHome);
-        if (!pathExists.sync(javaHome)) {
-            reject();
-        }
-        if (!pathExists.sync(path.resolve(javaHome, 'bin', JAVAC_FILENAME))) {
-            reject();
-        }
-        return resolve(javaHome);
+        findJavaHome((err, home) => {
+            if (err) {
+                reject(err);
+            }
+            resolve(javaHome);
+        })
     });
 }
 


### PR DESCRIPTION
Signed-off-by: xuzho <xuzho@microsoft.com>

i suppose we could save time to call `find-java-home` directly, but i'm not sure whether there is any potential bug that vscode-java extension would do some check themselves and use find-java-home as last resort, let's follow vscode-java 's behavior first. I would update the logic after the release since by then we have plenty time to test