### PR TITLE
fix some minor bugs

### DIFF
--- a/extension/src/classPathManager.ts
+++ b/extension/src/classPathManager.ts
@@ -3,9 +3,13 @@
 
 import { workspace, CancellationToken, Uri } from 'vscode';
 import * as Commands from './commands';
+import { Logger } from './logger';
 
 export class ClassPathManager {
     private classPathCache = new Map<string, string[]>();
+
+    constructor(private _logger: Logger) {
+    }
 
     public async refresh(token?: CancellationToken): Promise<void[]> {
         return Promise.all(workspace.workspaceFolders.map((wkspace) => {
@@ -16,6 +20,7 @@ export class ClassPathManager {
                 if (token.isCancellationRequested) {
                     return;
                 }
+                this._logger.logError(`Failed to refresh class path. Details: ${reason}.`);
                 return Promise.reject(reason);
             });
         }));

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -34,10 +34,10 @@ import { TestResultAnalyzer } from './testResultAnalyzer';
 const isWindows = process.platform.indexOf('win') === 0;
 const JAVAC_FILENAME = 'javac' + (isWindows ? '.exe' : '');
 const onDidChange: EventEmitter<void> = new EventEmitter<void>();
-const testResourceManager: TestResourceManager = new TestResourceManager();
-const classPathManager: ClassPathManager = new ClassPathManager();
 const outputChannel: OutputChannel = window.createOutputChannel('Test Output');
 const logger: Logger = new Logger(outputChannel);
+const testResourceManager: TestResourceManager = new TestResourceManager(logger);
+const classPathManager: ClassPathManager = new ClassPathManager(logger);
 let running: boolean = false;
 
 // this method is called when your extension is activated

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -35,7 +35,7 @@ const isWindows = process.platform.indexOf('win') === 0;
 const JAVAC_FILENAME = 'javac' + (isWindows ? '.exe' : '');
 const onDidChange: EventEmitter<void> = new EventEmitter<void>();
 const outputChannel: OutputChannel = window.createOutputChannel('Test Output');
-const logger: Logger = new Logger(outputChannel);
+const logger: Logger = new Logger(outputChannel); // TO-DO: refactor Logger. Make logger stateless and no need to pass the instance.
 const testResourceManager: TestResourceManager = new TestResourceManager(logger);
 const classPathManager: ClassPathManager = new ClassPathManager(logger);
 let running: boolean = false;

--- a/extension/src/fetchTestUtility.ts
+++ b/extension/src/fetchTestUtility.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { TextDocument } from "vscode";
+import * as Commands from './commands';
+import { TestSuite } from "./protocols";
+
+export function fetchTests(document: TextDocument): Thenable<TestSuite[]> {
+    return Commands.executeJavaLanguageServerCommand(Commands.JAVA_FETCH_TEST, document.uri.toString()).then((tests: TestSuite[]) => {
+        transformIndex(tests);
+        return tests;
+    },
+    (reason) => {
+        return Promise.reject(reason);
+    });
+}
+
+function transformIndex(tests: TestSuite[]): void {
+    tests.map((t) => {
+        if (t.parentIndex !== undefined) {
+            t.parent = tests[t.parentIndex];
+        }
+        if (t.childrenIndices) {
+            t.children = t.childrenIndices.map((i) => tests[i]);
+        }
+    });
+}

--- a/extension/src/protocols.ts
+++ b/extension/src/protocols.ts
@@ -12,9 +12,9 @@ export type TestSuite = {
     range: Range;
     uri: string;
     test: string;
-    parentIndex: number; // local per file
+    parentIndex?: number; // local per file
     parent: TestSuite;
-    childrenIndices: number[]; // local per file
+    childrenIndices?: number[]; // local per file
     children: TestSuite[];
     packageName: string;
     level: TestLevel;

--- a/extension/src/testResourceManager.ts
+++ b/extension/src/testResourceManager.ts
@@ -1,18 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { workspace, Uri } from 'vscode';
+import { commands, workspace, Uri } from 'vscode';
+import * as Commands from './commands';
+import { Logger } from './logger';
 import { Test, TestSuite } from './protocols';
 
 export class TestResourceManager {
     private testsIndexedByFileUri = new Map<string, Test | null | undefined>();
 
+    constructor(private _logger: Logger) {
+    }
+
     public getTests(file: Uri): Test | undefined {
-        const path = file.path || '';
+        const path = file.fsPath || '';
         return this.testsIndexedByFileUri.has(path) ? this.testsIndexedByFileUri.get(path) : undefined;
     }
     public storeTests(file: Uri, tests: TestSuite[] | null | undefined): void {
-        const path = file.path || '';
+        const path = file.fsPath || '';
         const test: Test = {
             dirty: false,
             tests,


### PR DESCRIPTION
use fspath rather than path as test storage cache's key because fspath would transform windows path to lower case;
fix a bug when resolving parent; and move the logic to fetchtestUtility.ts

Signed-off-by: xuzho <xuzho@microsoft.com>