### PR TITLE
wait for test resource manager to load all tests when activating the extension

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -44,9 +44,10 @@ let running: boolean = false;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
     activateTelemetry(context);
-    testResourceManager.refresh();
+    // to-do: add status to show it is loading tests.
+    await testResourceManager.refresh();
     const codeLensProvider = new JUnitCodeLensProvider(onDidChange, testResourceManager, logger);
     context.subscriptions.push(languages.registerCodeLensProvider(Configs.LANGUAGE, codeLensProvider));
     const testReportProvider: TestReportProvider = new TestReportProvider(context, testResourceManager);


### PR DESCRIPTION
Signed-off-by: xuzho <xuzho@microsoft.com>

To fix bug #66

if codelens is resolved and triggered running tests before test resource explorer loads all tests, the test result might be lost