### PR TITLE
fix bug: test explorer class node's name is wrongly trimmed for default package case

### DIFF
--- a/extension/src/Explorer/testExplorer.ts
+++ b/extension/src/Explorer/testExplorer.ts
@@ -104,7 +104,7 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
         if (test.level === TestLevel.Method) {
             return test.test.substring(test.test.indexOf('#') + 1);
         } else {
-            return test.test.substring(test.packageName.length + 1);
+            return test.test.substring(test.packageName === '' ? 0 : test.packageName.length + 1);
         }
     }
 


### PR DESCRIPTION
fix #86

Signed-off-by: xuzho <xuzho@microsoft.com>