### PR TITLE
walkaround: test explorer would disappear when user open test report

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -43,7 +43,7 @@
                 {
                     "id": "testExplorer",
                     "name": "Test Explorer",
-                    "when": "resourceLangId == 'java'"
+                    "when": "resourceExtname == '.java'"
                 }
             ]
         },

--- a/extension/src/testReportProvider.ts
+++ b/extension/src/testReportProvider.ts
@@ -88,7 +88,7 @@ export class TestReportProvider implements TextDocumentContentProvider {
 
 export function encodeTestSuite(test: TestSuite[], type: TestReportType = TestReportType.All): Uri {
     const query = JSON.stringify([test.map((t) => t.uri), test.map((t) => t.test), type]);
-    return Uri.parse(`${TestReportProvider.scheme}:${parseTestReportName(test, type)}?${encodeURIComponent(query)}`);
+    return Uri.parse(`${TestReportProvider.scheme}:${parseTestReportName(test, type)}.java?${encodeURIComponent(query)}`);
 }
 
 export function decodeTestSuite(uri: Uri): [Uri[], string[], TestReportType] {


### PR DESCRIPTION
Signed-off-by: xuzho <xuzho@microsoft.com>

currently , when user opens test report, test explorer would disappear. We might need combined conditions to determine when the explorer would show. However, seems vscode hasn't support complex condition for explorer view yet(opened an issue https://github.com/Microsoft/vscode/issues/43407 to track), so the fix still wouldn't work when user open 'pom.xml', but i think that is a rare case when user need the test explorer to be around.