### PR TITLE
add default config

### DIFF
--- a/extension/src/Constants/configs.ts
+++ b/extension/src/Constants/configs.ts
@@ -4,5 +4,5 @@
 export const LANGUAGE = 'java';
 export const LOG_FILE_NAME = 'java_test_runner.log';
 export const MAX_CLASS_PATH_LENGTH = 4096;
-export const TEST_LAUNCH_CONFIG_NAME = 'test-launch.json';
+export const TEST_LAUNCH_CONFIG_NAME = 'test.launch.json';
 export const CHILD_PROCESS_MAX_BUFFER_SIZE = 1024 * 1024;

--- a/extension/src/Explorer/testExplorer.ts
+++ b/extension/src/Explorer/testExplorer.ts
@@ -7,7 +7,7 @@ import { window, workspace, Event, EventEmitter, ExtensionContext, TreeDataProvi
 import { TestResourceManager } from '../testResourceManager';
 import * as Commands from '../Constants/commands';
 import { TestLevel, TestSuite } from '../Models/protocols';
-import { RunConfig } from '../Models/testConfig';
+import { RunConfigItem } from '../Models/testConfig';
 import { TestRunnerWrapper } from '../Runner/testRunnerWrapper';
 import { TestTreeNode, TestTreeNodeType } from './testTreeNode';
 
@@ -54,7 +54,7 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
         });
     }
 
-    public run(element: TestTreeNode, debugMode: boolean, config?: RunConfig) {
+    public run(element: TestTreeNode, debugMode: boolean, config?: RunConfigItem) {
         return TestRunnerWrapper.run(this.resolveTestSuites(element), debugMode, config);
     }
 

--- a/extension/src/Models/testConfig.ts
+++ b/extension/src/Models/testConfig.ts
@@ -2,11 +2,16 @@
 // Licensed under the MIT license.
 
 export type TestConfig = {
-    run: RunConfig[];
-    debug: RunConfig[];
+    run: RunConfig;
+    debug: RunConfig;
 };
 
 export type RunConfig = {
+    default: string;
+    items: RunConfigItem[];
+};
+
+export type RunConfigItem = {
     name: string;
     projectName: string;
     workingDirectory: string;

--- a/extension/src/Runner/JarFileRunner/jarFileTestRunner.ts
+++ b/extension/src/Runner/JarFileRunner/jarFileTestRunner.ts
@@ -5,7 +5,7 @@ import { ClassPathManager } from '../../classPathManager';
 import { TestStatusBarProvider } from '../../testStatusBarProvider';
 import * as Configs from '../../Constants/configs';
 import { TestSuite } from '../../Models/protocols';
-import { RunConfig, TestConfig } from '../../Models/testConfig';
+import { RunConfigItem, TestConfig } from '../../Models/testConfig';
 import { ClassPathUtility } from '../../Utils/classPathUtility';
 import * as Logger from '../../Utils/Logger/logger';
 import { ITestResult } from '../testModel';
@@ -37,7 +37,7 @@ export abstract class JarFileTestRunner implements ITestRunner {
     public abstract constructCommand(params: IJarFileTestRunnerParameters): Promise<string>;
     public abstract getTestResultAnalyzer(params: IJarFileTestRunnerParameters): JarFileRunnerResultAnalyzer;
 
-    public async setup(tests: TestSuite[], isDebugMode: boolean, config: RunConfig): Promise<ITestRunnerParameters> {
+    public async setup(tests: TestSuite[], isDebugMode: boolean, config: RunConfigItem): Promise<ITestRunnerParameters> {
         const uris: Uri[] = tests.map((t) => Uri.parse(t.uri));
         const classpaths: string[] = this._classPathManager.getClassPaths(uris);
         const port: number | undefined = isDebugMode ? await this.getPortWithWrapper() : undefined;

--- a/extension/src/Runner/testRunner.ts
+++ b/extension/src/Runner/testRunner.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { RunConfig } from '../Models/testConfig';
+import { RunConfigItem } from '../Models/testConfig';
 import { ITestInfo, ITestResult } from './testModel';
 import { ITestRunnerParameters } from './testRunnerParameters';
 
 export interface ITestRunner {
-    setup(tests: ITestInfo[], isDebugMode: boolean, config: RunConfig): Promise<ITestRunnerParameters>;
+    setup(tests: ITestInfo[], isDebugMode: boolean, config: RunConfigItem): Promise<ITestRunnerParameters>;
     run(params: ITestRunnerParameters): Promise<ITestResult[]>;
     postRun(): Promise<void>;
     cancel(): Promise<void>;

--- a/extension/src/Runner/testRunnerParameters.ts
+++ b/extension/src/Runner/testRunnerParameters.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { RunConfig } from '../Models/testConfig';
+import { RunConfigItem } from '../Models/testConfig';
 import { ITestInfo } from './testModel';
 
 export interface ITestRunnerParameters {
@@ -9,5 +9,5 @@ export interface ITestRunnerParameters {
     isDebugMode: boolean;
     storagePath: string;
     port: number | undefined;
-    config: RunConfig;
+    config: RunConfigItem;
 }

--- a/extension/src/Runner/testRunnerWrapper.ts
+++ b/extension/src/Runner/testRunnerWrapper.ts
@@ -5,7 +5,7 @@ import { ClassPathManager } from '../classPathManager';
 import { TestStatusBarProvider } from '../testStatusBarProvider';
 import * as Configs from '../Constants/configs';
 import { TestKind, TestLevel, TestResult, TestStatus, TestSuite } from '../Models/protocols';
-import { RunConfig } from '../Models/testConfig';
+import { RunConfigItem } from '../Models/testConfig';
 import * as Logger from '../Utils/Logger/logger';
 import { ITestResult } from './testModel';
 import { ITestRunner } from './testRunner';
@@ -20,7 +20,7 @@ export class TestRunnerWrapper {
         TestRunnerWrapper.runnerPool.set(kind, runner);
     }
 
-    public static async run(tests: TestSuite[], isDebugMode: boolean, config: RunConfig): Promise<void> {
+    public static async run(tests: TestSuite[], isDebugMode: boolean, config: RunConfigItem): Promise<void> {
         if (TestRunnerWrapper.running) {
             window.showInformationMessage('A test session is currently running. Please wait until it finishes.');
             Logger.info('Skip this run cause we only support running one session at the same time');

--- a/extension/src/testConfigManager.ts
+++ b/extension/src/testConfigManager.ts
@@ -90,26 +90,32 @@ export class TestConfigManager {
     private createDefaultTestConfig(): TestConfig {
         const projects: ProjectInfo[] = this._projectManager.getAll();
         const config: TestConfig = {
-            run: projects.map((i) => {
-                return {
-                    name: i.name,
-                    projectName: i.name,
-                    workingDirectory: workspace.getWorkspaceFolder(i.path).uri.fsPath,
-                    args: [],
-                    vmargs: [],
-                    preLaunchTask: '',
-                };
-            }),
-            debug: projects.map((i) => {
-                return {
-                    name: i.name,
-                    projectName: i.name,
-                    workingDirectory: workspace.getWorkspaceFolder(i.path).uri.fsPath,
-                    args: [],
-                    vmargs: [],
-                    preLaunchTask: '',
-                };
-            }),
+            run: {
+                default: '',
+                items: projects.map((i) => {
+                    return {
+                        name: i.name,
+                        projectName: i.name,
+                        workingDirectory: workspace.getWorkspaceFolder(i.path).uri.fsPath,
+                        args: [],
+                        vmargs: [],
+                        preLaunchTask: '',
+                    };
+                }),
+            },
+            debug: {
+                default: '',
+                items: projects.map((i) => {
+                    return {
+                        name: i.name,
+                        projectName: i.name,
+                        workingDirectory: workspace.getWorkspaceFolder(i.path).uri.fsPath,
+                        args: [],
+                        vmargs: [],
+                        preLaunchTask: '',
+                    };
+                }),
+            },
         };
         return config;
     }


### PR DESCRIPTION
Signed-off-by: xuzho <xuzho@microsoft.com>

1. add `default` section in test configuration. This way, user could specify the default config to pick when invoking "Run test".
2. rename test config file from "test-launch.json" to 'test.launch.json' as we changed the format of test configuration file and it isn't back-compatible