### PR TITLE
behavior change: always show test report and update test status even if runner failed

### DIFF
--- a/extension/src/Runner/testRunnerWrapper.ts
+++ b/extension/src/Runner/testRunnerWrapper.ts
@@ -35,9 +35,14 @@ export class TestRunnerWrapper {
                         await this.execPreLaunchTask(config.workingDirectory, config.preLaunchTask);
                     }
                     const params = await runner.setup(t, isDebugMode, config);
-                    const res = await runner.run(params);
-                    this.updateTestStorage(t, res);
-                    await runner.postRun();
+                    await runner.run(params).then(async (res) => {
+                        this.updateTestStorage(t, res);
+                        await runner.postRun();
+                    }, async ([error, res]) => {
+                        this.updateTestStorage(t, res);
+                        await runner.postRun();
+                        throw error;
+                    });
                 }
             })());
         } finally {

--- a/extension/src/testStatusBarProvider.ts
+++ b/extension/src/testStatusBarProvider.ts
@@ -53,14 +53,17 @@ export class TestStatusBarProvider {
                 this.updateStatus(tests);
                 p.report({ increment: 100 });
             },
-                (reason) => {
-                    this.statusBarItem.text = 'Failed to run tests';
-                    this.statusBarItem.color = 'red';
-                    Logger.error('Failed to run tests.', {
-                        error: reason,
-                    });
-                    return Promise.reject(reason);
+            (reason) => {
+                this.statusBarItem.text = 'Failed to run tests';
+                this.statusBarItem.color = 'red';
+                if (tests) {
+                    this.statusBarItem.command = CommandUtility.getCommandWithArgs(Commands.JAVA_TEST_SHOW_REPORT, [tests]);
+                }
+                Logger.error('Failed to run tests.', {
+                    error: reason,
                 });
+                return Promise.reject(reason);
+            });
         });
     }
 


### PR DESCRIPTION

Signed-off-by: xuzho <xuzho@microsoft.com>

previous: if runner failed, e.g. cancel a test run, then the partial result won't be updated
current: always update test result even if it is partial