### PR TITLE
remove cancel test button from test explorer as it is a little bit confusing

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -61,11 +61,6 @@
                     "command": "java.test.explorer.debug",
                     "when": "view == testExplorer",
                     "group": "navigation@1"
-                },
-                {
-                    "command": "java.test.explorer.cancel",
-                    "when": "view == testExplorer",
-                    "group": "navigation@2"
                 }
             ],
             "view/item/context": [
@@ -116,12 +111,8 @@
                 "category": "Java"
             },
             {
-                "command": "java.test.explorer.cancel",
+                "command": "java.test.cancel",
                 "title": "Cancel Test",
-                "icon": {
-                    "light": "resources/media/light/placeholder.png",
-                    "dark": "resources/media/dark/placeholder.png"
-                },
                 "category": "Java"
             },
             {

--- a/extension/src/Constants/commands.ts
+++ b/extension/src/Constants/commands.ts
@@ -21,8 +21,6 @@ export const JAVA_TEST_EXPLORER_RUN_TEST = 'java.test.explorer.run';
 
 export const JAVA_TEST_EXPLORER_DEBUG_TEST = 'java.test.explorer.debug';
 
-export const JAVA_TEST_EXPLORER_CANCEL_TEST = 'java.test.explorer.cancel';
-
 export const JAVA_TEST_EXPLORER_RUN_TEST_WITH_CONFIG = 'java.test.explorer.run.config';
 
 export const JAVA_TEST_EXPLORER_DEBUG_TEST_WITH_CONFIG = 'java.test.explorer.debug.config';
@@ -30,6 +28,8 @@ export const JAVA_TEST_EXPLORER_DEBUG_TEST_WITH_CONFIG = 'java.test.explorer.deb
 export const JAVA_TEST_SHOW_OUTPUT = 'java.test.show.output';
 
 export const JAVA_TEST_OPEN_LOG = 'java.test.open.log';
+
+export const JAVA_TEST_CANCEL = 'java.test.cancel';
 
 export const JAVA_CONFIGURE_TEST_COMMAND = 'java.test.configure';
 

--- a/extension/src/Explorer/testExplorer.ts
+++ b/extension/src/Explorer/testExplorer.ts
@@ -58,10 +58,6 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
         return TestRunnerWrapper.run(this.resolveTestSuites(element), debugMode, config);
     }
 
-    public cancelRun(): Promise<void> {
-        return TestRunnerWrapper.cancel();
-    }
-
     private createTestTreeNode(
         tests: TestSuite[],
         parent: TestTreeNode,

--- a/extension/src/Utils/Logger/outputTransport.ts
+++ b/extension/src/Utils/Logger/outputTransport.ts
@@ -14,7 +14,7 @@ export class OutputTransport extends winston.Transport {
         Commands.JAVA_DEBUG_TEST_COMMAND,
         Commands.JAVA_TEST_EXPLORER_RUN_TEST,
         Commands.JAVA_TEST_EXPLORER_DEBUG_TEST,
-        Commands.JAVA_TEST_EXPLORER_CANCEL_TEST,
+        Commands.JAVA_TEST_CANCEL,
         Commands.JAVA_TEST_EXPLORER_RUN_TEST_WITH_CONFIG,
         Commands.JAVA_TEST_EXPLORER_DEBUG_TEST_WITH_CONFIG,
     ]);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -111,8 +111,8 @@ export async function activate(context: ExtensionContext) {
             openTestLogFile(context.asAbsolutePath(Configs.LOG_FILE_NAME))));
         context.subscriptions.push(TelemetryWrapper.registerCommand(Commands.JAVA_CONFIGURE_TEST_COMMAND, () =>
             testConfigManager.editConfig()));
-        context.subscriptions.push(TelemetryWrapper.registerCommand(Commands.JAVA_TEST_EXPLORER_CANCEL_TEST, () =>
-            testExplorer.cancelRun()));
+        context.subscriptions.push(TelemetryWrapper.registerCommand(Commands.JAVA_TEST_CANCEL, () =>
+            TestRunnerWrapper.cancel()));
         TestRunnerWrapper.registerRunner(TestKind.JUnit, new JUnitTestRunner(javaHome, context.storagePath, classPathManager, onDidChange));
         TestRunnerWrapper.registerRunner(TestKind.JUnit5, new JUnit5TestRunner(javaHome, context.storagePath, classPathManager, onDidChange));
         classPathManager.refresh();

--- a/extension/src/testStatusBarProvider.ts
+++ b/extension/src/testStatusBarProvider.ts
@@ -46,7 +46,7 @@ export class TestStatusBarProvider {
         return window.withProgress({ location: ProgressLocation.Notification, title: 'Running tests', cancellable: true }, (p, token) => {
             token.onCancellationRequested(() => {
                 Logger.info('User canceled the long running operation');
-                commands.executeCommand(Commands.JAVA_TEST_EXPLORER_CANCEL_TEST);
+                commands.executeCommand(Commands.JAVA_TEST_CANCEL);
             });
             p.report({ message: 'Running tests...', increment: 0 });
             return action.then(() => {


### PR DESCRIPTION

Signed-off-by: xuzho <xuzho@microsoft.com>

A better way to show cancel button on test explorer is it would replace original `Run test` button once a test run is started. Currently tree explorer icon couldn't be dynamically updated, so remove it to avoid confusing.