### PR TITLE
change config behvior: now each workspace folder would contain a launch.test.json

### DIFF
--- a/extension/src/testConfigManager.ts
+++ b/extension/src/testConfigManager.ts
@@ -4,10 +4,11 @@
 import * as fs from 'fs';
 import * as mkdirp from 'mkdirp';
 import * as path from 'path';
-import { window, workspace, ExtensionContext, TextEditor } from 'vscode';
+import { window, workspace, ExtensionContext, TextEditor, Uri, WorkspaceFolder } from 'vscode';
 
 import { ProjectInfo, ProjectManager } from './projectManager';
 import * as Configs from './Constants/configs';
+import { TestSuite } from './Models/protocols';
 import { TestConfig } from './Models/testConfig';
 import * as Logger from './Utils/Logger/logger';
 
@@ -18,17 +19,22 @@ export class TestConfigManager {
         if (!workspaceFolders) {
             throw new Error('Not supported without a folder!');
         }
-        this._configPath = path.join(workspaceFolders[0].uri.fsPath, '.vscode', Configs.TEST_LAUNCH_CONFIG_NAME);
+        this._configPath = path.join('.vscode', Configs.TEST_LAUNCH_CONFIG_NAME);
     }
 
     public get configPath(): string {
         return this._configPath;
     }
 
-    public async loadConfig(): Promise<TestConfig> {
-        await this.createTestConfigIfNotExisted();
-        return new Promise<TestConfig>((resolve, reject) => {
-            fs.readFile(this._configPath, 'utf-8', (readErr, data) => {
+    public async loadConfig(tests: TestSuite[]): Promise<TestConfig[]> {
+        const folders = [...new Set(tests.map((t) => {
+            const f = workspace.getWorkspaceFolder(Uri.parse(t.uri));
+            return f ? f : undefined;
+        }).filter((t) => t))];
+        return Promise.all(folders.map((f) => new Promise<TestConfig>(async (resolve, reject) => {
+            const fullPath = path.join(f.uri.fsPath, this._configPath);
+            await this.createTestConfigIfNotExisted(f);
+            fs.readFile(fullPath, 'utf-8', (readErr, data) => {
                 if (readErr) {
                     Logger.error('Failed to read the test config!', {
                         error: readErr,
@@ -45,13 +51,19 @@ export class TestConfigManager {
                     reject(ex);
                 }
             });
-        });
+        })));
     }
 
     public editConfig(): Promise<TextEditor> {
         const editor = window.activeTextEditor;
-        return this.createTestConfigIfNotExisted().then(() => {
-            return workspace.openTextDocument(this._configPath).then((doc) => {
+        let folder = workspace.getWorkspaceFolder(editor.document.uri);
+        if (!folder) {
+            Logger.warn(`Active file isn't within a folder, use first folder instead.`);
+            folder = workspace.workspaceFolders[0];
+        }
+        return this.createTestConfigIfNotExisted(folder).then(() => {
+            const fullPath = path.join(folder.uri.fsPath, this._configPath);
+            return workspace.openTextDocument(fullPath).then((doc) => {
                 return window.showTextDocument(doc, editor ? editor.viewColumn : undefined);
             }, (err) => {
                 return Promise.reject(err);
@@ -59,20 +71,21 @@ export class TestConfigManager {
         });
     }
 
-    private createTestConfigIfNotExisted(): Promise<void> {
+    private createTestConfigIfNotExisted(folder: WorkspaceFolder): Promise<void> {
         return new Promise((resolve, reject) => {
-            mkdirp(path.dirname(this._configPath), (merr) => {
+            const configFullPath = path.join(folder.uri.fsPath, this._configPath);
+            mkdirp(path.dirname(configFullPath), (merr) => {
                 if (merr && merr.code !== 'EEXIST') {
-                    Logger.error(`Failed to create sub directory for this config. File path: ${this._configPath}`, {
+                    Logger.error(`Failed to create sub directory for this config. File path: ${configFullPath}`, {
                         error: merr,
                     });
                     return reject(merr);
                 }
-                fs.access(this._configPath, (err) => {
+                fs.access(configFullPath, (err) => {
                     if (err) {
-                        const config: TestConfig = this.createDefaultTestConfig();
+                        const config: TestConfig = this.createDefaultTestConfig(folder.uri);
                         const content: string = JSON.stringify(config, null, 4);
-                        fs.writeFile(this._configPath, content, 'utf-8', (writeErr) => {
+                        fs.writeFile(configFullPath, content, 'utf-8', (writeErr) => {
                             if (writeErr) {
                                 Logger.error('Failed to create default test config!', {
                                     error: writeErr,
@@ -87,8 +100,8 @@ export class TestConfigManager {
         });
     }
 
-    private createDefaultTestConfig(): TestConfig {
-        const projects: ProjectInfo[] = this._projectManager.getAll();
+    private createDefaultTestConfig(folder: Uri): TestConfig {
+        const projects: ProjectInfo[] = this._projectManager.getProjects(folder);
         const config: TestConfig = {
             run: {
                 default: '',


### PR DESCRIPTION

Signed-off-by: xuzho <xuzho@microsoft.com>

previously if we trigger tests from multiple workspace folders. e.g. `Run all` from test explorer, then the launch.test.json would be placed in the first workspace folder, which is inappropriate as if user later opens the second workspace folder directly from vscode, they would lose their config files.

However, we still don't support running with config for multi-root case as there is no place to store the highest level config file.