### PR TITLE
change report refresh behavior when test files are changed but the test hasn't been rerun

### DIFF
--- a/extension/resources/templates/report.pug
+++ b/extension/resources/templates/report.pug
@@ -12,6 +12,8 @@ html(lang="en")
     body.bg-dark(style='padding-top:70px;')
         .navbar.navbar-dark.bg-dark.fixed-top.navbar-expand-sm
             a.navbar-brand(href='#') Test Report
+            if isLegacy
+                div.text-light Test file has been changed, try rerun the test again...
             if showFilters
                 div.collapse.navbar-collapse
                     ul.navbar-nav

--- a/extension/resources/templates/report.pug
+++ b/extension/resources/templates/report.pug
@@ -13,7 +13,7 @@ html(lang="en")
         .navbar.navbar-dark.bg-dark.fixed-top.navbar-expand-sm
             a.navbar-brand(href='#') Test Report
             if isLegacy
-                div.text-light Test file has been changed, try rerun the test again...
+                div.text-warning Test file has been changed, try rerun the test again...
             if showFilters
                 div.collapse.navbar-collapse
                     ul.navbar-nav


### PR DESCRIPTION
previous: show error report
now: error snippets are prepended in previous report so user could still view previous report before rerunning the test.

Signed-off-by: xuzho <xuzho@microsoft.com>