### PR TITLE
add retry logic for file create and add more details for error message

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-java-test",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/extension/src/Constants/configs.ts
+++ b/extension/src/Constants/configs.ts
@@ -6,3 +6,5 @@ export const LOG_FILE_NAME = 'java_test_runner.log';
 export const MAX_CLASS_PATH_LENGTH = 4096;
 export const TEST_LAUNCH_CONFIG_NAME = 'launch.test.json';
 export const CHILD_PROCESS_MAX_BUFFER_SIZE = 1024 * 1024;
+export const DISK_IO_RETRY_COUNT = 3;
+export const DISK_IO_RETRY_DELAY_MILLISECONDS = 100;

--- a/extension/src/Utils/Logger/telemetryTransport.ts
+++ b/extension/src/Utils/Logger/telemetryTransport.ts
@@ -26,7 +26,7 @@ export class TelemetryTransport extends winston.Transport {
         try {
             TelemetryWrapper.sendTelemetryEvent(this.toTelemetryEvent(logLevel), {
                 message: msg,
-                meta,
+                ...meta,
             });
         } catch (telemetryErr) {
             Logger.error('Failed to send telemetry event. error: ' + telemetryErr);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -215,7 +215,8 @@ async function getTestConfig(tests: TestSuite[], isDebugMode: boolean, isDefault
     try {
         configs = await testConfigManager.loadConfig(tests);
     } catch (ex) {
-        window.showErrorMessage('Failed to load the test config! Please check whether your test configuration is a valid JSON file');
+        window.showErrorMessage(
+            `Failed to load the test config! Please check whether your test configuration is a valid JSON file. Details: ${ex.message}.`);
         throw ex;
     }
     const runConfigs: RunConfig[] = isDebugMode ? configs.map((c) => c.debug) : configs.map((c) => c.run);

--- a/extension/src/testConfigManager.ts
+++ b/extension/src/testConfigManager.ts
@@ -25,11 +25,10 @@ export class TestConfigManager {
     public async loadConfig(tests: TestSuite[]): Promise<TestConfig[]> {
         const folders = [...new Set(tests.map((t) => workspace.getWorkspaceFolder(Uri.parse(t.uri))).filter((t) => t))];
         return Promise.all(folders.map((f) => new Promise<TestConfig>(async (resolve, reject) => {
-            const fullPath = path.join(f.uri.fsPath, this._configPath);
-            await this.createTestConfigIfNotExisted(f);
+            const fullPath = await this.createTestConfigIfNotExisted(f);
             fs.readFile(fullPath, 'utf-8', (readErr, data) => {
                 if (readErr) {
-                    Logger.error('Failed to read the test config!', {
+                    Logger.error(`Failed to read the test config! Details: ${readErr.message}.`, {
                         error: readErr,
                     });
                     return reject(readErr);
@@ -38,7 +37,7 @@ export class TestConfigManager {
                     const config: TestConfig = JSON.parse(data) as TestConfig;
                     resolve(config);
                 } catch (ex) {
-                    Logger.error('Failed to parse the test config!', {
+                    Logger.error(`Failed to parse the test config! Details: ${ex.message}.`, {
                         error: ex,
                     });
                     reject(ex);
@@ -57,8 +56,7 @@ export class TestConfigManager {
             Logger.warn(`Active file isn't within a folder, use first folder instead.`);
             folder = workspace.workspaceFolders[0];
         }
-        return this.createTestConfigIfNotExisted(folder).then(() => {
-            const fullPath = path.join(folder.uri.fsPath, this._configPath);
+        return this.createTestConfigIfNotExisted(folder).then((fullPath) => {
             return workspace.openTextDocument(fullPath).then((doc) => {
                 return window.showTextDocument(doc, editor ? editor.viewColumn : undefined);
             }, (err) => {
@@ -67,33 +65,37 @@ export class TestConfigManager {
         });
     }
 
-    private createTestConfigIfNotExisted(folder: WorkspaceFolder): Promise<void> {
-        return new Promise((resolve, reject) => {
+    private createTestConfigIfNotExisted(folder: WorkspaceFolder): Promise<string> {
+        return this.withRetry(new Promise((resolve, reject) => {
             const configFullPath = path.join(folder.uri.fsPath, this._configPath);
             mkdirp(path.dirname(configFullPath), (merr) => {
                 if (merr && merr.code !== 'EEXIST') {
-                    Logger.error(`Failed to create sub directory for this config.`, {
+                    Logger.error(`Failed to create sub directory for this config. Details: ${merr.message}.`, {
                         error: merr,
                     });
                     return reject(merr);
                 }
-                fs.access(configFullPath, (err) => {
+                fs.open(configFullPath, 'wx', (err) => {
                     if (err) {
+                        if (err.code !== 'EEXIST') {
+                            return reject(err);
+                        }
+                    } else {
                         const config: TestConfig = this.createDefaultTestConfig(folder.uri);
                         const content: string = JSON.stringify(config, null, 4);
                         fs.writeFile(configFullPath, content, 'utf-8', (writeErr) => {
                             if (writeErr) {
-                                Logger.error('Failed to create default test config!', {
+                                Logger.error(`Failed to create default test config! Details: ${writeErr.message}.`, {
                                     error: writeErr,
                                 });
                                 return reject(writeErr);
                             }
                         });
                     }
-                    resolve();
+                    resolve(configFullPath);
                 });
             });
-        });
+        }), Configs.DISK_IO_RETRY_COUNT, Configs.DISK_IO_RETRY_DELAY_MILLISECONDS);
     }
 
     private createDefaultTestConfig(folder: Uri): TestConfig {
@@ -129,5 +131,29 @@ export class TestConfigManager {
             },
         };
         return config;
+    }
+
+    private withRetry<T>(request: Promise<T>, retryTimes: number, retryDelayInMillisecond: number): Promise<T> {
+        return new Promise<T>(async (resolve, reject) => {
+            let count: number = 0;
+            let error;
+            while (count < retryTimes) {
+                try {
+                    const res = await request;
+                    resolve(res);
+                    return;
+                } catch (ex) {
+                    error = ex;
+                    await new Promise((r) => {
+                        setTimeout(() => {
+                            r();
+                        }, retryDelayInMillisecond);
+                    });
+                } finally {
+                    count++;
+                }
+            }
+            reject(error);
+        });
     }
 }


### PR DESCRIPTION
Signed-off-by: xuzho <xuzho@microsoft.com>

#213 #230 
I still cannot repro this scenario, actions:
1. fix telemetry log issue, `meta` would be record as [object, object] string literal.
2. add more detailed error message.
3. add retry logic for disk write
4. change file write logic: reference [the recommended way to write file in node](https://nodejs.org/api/fs.html#fs_fs_access_path_mode_callback)