### PR TITLE
rewrite junit runner to generate unified output/error

### DIFF
--- a/com.microsoft.java.test.runner/pom.xml
+++ b/com.microsoft.java.test.runner/pom.xml
@@ -16,6 +16,11 @@
       <artifactId>junit</artifactId>
       <version>4.8.2</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/CustomizedJUnitCoreRunner.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/CustomizedJUnitCoreRunner.java
@@ -24,7 +24,7 @@ public class CustomizedJUnitCoreRunner extends JUnitCore {
     public void run(String[] suites) {
         List<JUnit4TestReference> testSuites = TestRunnerUtil.createTestReferences(suites);
         if (testSuites.isEmpty()) {
-            TestingMessageHelper.reporterAttached(TestOutputSream.Instance());
+            TestingMessageHelper.reporterAttached(TestOutputSream.instance());
             return;
         }
 

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/CustomizedJUnitCoreRunner.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/CustomizedJUnitCoreRunner.java
@@ -24,7 +24,7 @@ public class CustomizedJUnitCoreRunner extends JUnitCore {
     public void run(String[] suites) {
         List<JUnit4TestReference> testSuites = TestRunnerUtil.createTestReferences(suites);
         if (testSuites.isEmpty()) {
-            TestingMessageHelper.reporterAttached(System.out);
+            TestingMessageHelper.reporterAttached(TestOutputSream.Instance());
             return;
         }
 

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/JUnitLauncher.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/JUnitLauncher.java
@@ -16,10 +16,11 @@ public class JUnitLauncher {
     }
 
     private static int execute(String[] args) {
+        TestOutputSream stream = TestOutputSream.Instance();
         try {
             if (args.length == 0) {
-                TestingMessageHelper.reporterAttached(System.out);
-                System.err.print("No test found to run");
+                TestingMessageHelper.reporterAttached(stream);
+                stream.println(new TestReportItem(TestReportType.Error, null, null, "No test found to run", null));
             } else {
                 CustomizedJUnitCoreRunner jUnitCore = new CustomizedJUnitCoreRunner();
                 jUnitCore.run(args);
@@ -27,10 +28,10 @@ public class JUnitLauncher {
             return 0;
         } catch (Throwable e) {
             e.printStackTrace();
+            stream.println(new TestReportItem(TestReportType.Error, null, null, "Failed to launch Junit", e));
             return 1;
         } finally {
-            System.err.flush();
-            System.out.flush();
+            stream.flush();
         }
     }
 }

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/JUnitLauncher.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/JUnitLauncher.java
@@ -16,7 +16,7 @@ public class JUnitLauncher {
     }
 
     private static int execute(String[] args) {
-        TestOutputSream stream = TestOutputSream.Instance();
+        TestOutputSream stream = TestOutputSream.instance();
         try {
             if (args.length == 0) {
                 TestingMessageHelper.reporterAttached(stream);

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestOutputSream.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestOutputSream.java
@@ -13,18 +13,28 @@ public class TestOutputSream implements TestStream {
         this.out = System.out;
         this.err = System.err;
     }
-    
-    public static TestOutputSream Instance() {
+
+    public static TestOutputSream instance() {
         return instance;
     }
 
     @Override
     public void print(TestReportItem item) {
-        String content = ToJson(item);
+        String content = toJson(item);
         if (item.type == TestReportType.Error) {
             this.err.print(content);
         } else {
             this.out.print(content);
+        }
+    }
+
+    @Override
+    public void println(TestReportItem item) {
+        String content = toJson(item);
+        if (item.type == TestReportType.Error) {
+            this.err.println(content);
+        } else {
+            this.out.println(content);
         }
     }
 
@@ -34,17 +44,7 @@ public class TestOutputSream implements TestStream {
         this.err.flush();
     }
 
-    @Override
-    public void println(TestReportItem item) {
-        String content = ToJson(item);
-        if (item.type == TestReportType.Error) {
-            this.err.println(content);
-        } else {
-            this.out.println(content);
-        }
-    }
-    
-    private static String ToJson(TestReportItem item) {
+    private static String toJson(TestReportItem item) {
         Gson gson = new Gson();
         String jsonStr = gson.toJson(item);
         return "@@<RunnerOutput-" + jsonStr + "-RunnerOutput>@@";

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestOutputSream.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestOutputSream.java
@@ -1,0 +1,52 @@
+package com.microsoft.java.test.runner;
+
+import java.io.PrintStream;
+
+import com.google.gson.Gson;
+
+public class TestOutputSream implements TestStream {
+    private final PrintStream out;
+    private final PrintStream err;
+    private static final TestOutputSream instance = new TestOutputSream();
+
+    TestOutputSream() {
+        this.out = System.out;
+        this.err = System.err;
+    }
+    
+    public static TestOutputSream Instance() {
+        return instance;
+    }
+
+    @Override
+    public void print(TestReportItem item) {
+        String content = ToJson(item);
+        if (item.type == TestReportType.Error) {
+            this.err.print(content);
+        } else {
+            this.out.print(content);
+        }
+    }
+
+    @Override
+    public void flush() {
+        this.out.flush();
+        this.err.flush();
+    }
+
+    @Override
+    public void println(TestReportItem item) {
+        String content = ToJson(item);
+        if (item.type == TestReportType.Error) {
+            this.err.println(content);
+        } else {
+            this.out.println(content);
+        }
+    }
+    
+    private static String ToJson(TestReportItem item) {
+        Gson gson = new Gson();
+        String jsonStr = gson.toJson(item);
+        return jsonStr.length() + jsonStr;
+    }
+}

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestOutputSream.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestOutputSream.java
@@ -47,6 +47,6 @@ public class TestOutputSream implements TestStream {
     private static String ToJson(TestReportItem item) {
         Gson gson = new Gson();
         String jsonStr = gson.toJson(item);
-        return jsonStr.length() + jsonStr;
+        return "@@<RunnerOutput-" + jsonStr + "-RunnerOutput>@@";
     }
 }

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestReportItem.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestReportItem.java
@@ -1,0 +1,33 @@
+package com.microsoft.java.test.runner;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+
+public class TestReportItem {
+    String phase;
+
+    Map<String, String> attributes;
+
+    String message;
+
+    String stackTrace;
+    
+    TestReportType type;
+
+    public TestReportItem(TestReportType type, String phase, Map<String, String> attributes, String message, Throwable throwable) {
+        this.type = type;
+        this.phase = phase;
+        this.attributes = attributes;
+        this.message = message;
+        if (throwable != null) {
+            this.stackTrace = this.getStacktrace(throwable);
+        }
+    }
+
+    private String getStacktrace(Throwable throwable) {
+        StringWriter errors = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(errors));
+        return errors.toString();
+    }
+}

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestReportType.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestReportType.java
@@ -1,0 +1,6 @@
+package com.microsoft.java.test.runner;
+
+public enum TestReportType {
+    Info,
+    Error,
+}

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestRunnerUtil.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestRunnerUtil.java
@@ -50,7 +50,8 @@ public class TestRunnerUtil {
             Runner runner = request.getRunner();
             return singletonList(new JUnit4TestReference(runner, runner.getDescription()));
         } catch (ClassNotFoundException e) {
-            System.err.printf("No test found to run for suite %s. Details: %s.", suite, e.getMessage());
+            String message = String.format("No test found to run for suite %s. Details: %s.", suite, e.getMessage());
+            TestOutputSream.Instance().println(new TestReportItem(TestReportType.Error, null, null, message, e));
             return emptyList();
         }
     }
@@ -61,7 +62,8 @@ public class TestRunnerUtil {
             Runner runner = request.getRunner();
             return singletonList(new JUnit4TestReference(runner, runner.getDescription()));
         } catch (ClassNotFoundException e) {
-            System.err.printf("No test found to run for suite %s. Details: %s.", suite, e.getMessage());
+            String message = String.format("No test found to run for suite %s. Details: %s.", suite, e.getMessage());
+            TestOutputSream.Instance().println(new TestReportItem(TestReportType.Error, null, null, message, e));
             return emptyList();
         }
     }
@@ -75,11 +77,12 @@ public class TestRunnerUtil {
                 Runner runner = request.getRunner();
                 suites.add(new JUnit4TestReference(runner, runner.getDescription()));
             } catch (ClassNotFoundException ignored) {
-                System.err.printf("Failed to parse tests for suite %s. Details: %s.", classFqn, ignored.getMessage());
+                String message = String.format("Failed to parse tests for suite %s. Details: %s.", classFqn, ignored.getMessage());
+                TestOutputSream.Instance().println(new TestReportItem(TestReportType.Error, null, null, message, ignored));
             }
         }
         if (suites.isEmpty()) {
-            System.err.print("No test found to run.");
+            TestOutputSream.Instance().println(new TestReportItem(TestReportType.Error, null, null, "No test found to run.", null));
             return emptyList();
         }
         return suites;

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestRunnerUtil.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestRunnerUtil.java
@@ -51,7 +51,7 @@ public class TestRunnerUtil {
             return singletonList(new JUnit4TestReference(runner, runner.getDescription()));
         } catch (ClassNotFoundException e) {
             String message = String.format("No test found to run for suite %s. Details: %s.", suite, e.getMessage());
-            TestOutputSream.Instance().println(new TestReportItem(TestReportType.Error, null, null, message, e));
+            TestOutputSream.instance().println(new TestReportItem(TestReportType.Error, null, null, message, e));
             return emptyList();
         }
     }
@@ -63,7 +63,7 @@ public class TestRunnerUtil {
             return singletonList(new JUnit4TestReference(runner, runner.getDescription()));
         } catch (ClassNotFoundException e) {
             String message = String.format("No test found to run for suite %s. Details: %s.", suite, e.getMessage());
-            TestOutputSream.Instance().println(new TestReportItem(TestReportType.Error, null, null, message, e));
+            TestOutputSream.instance().println(new TestReportItem(TestReportType.Error, null, null, message, e));
             return emptyList();
         }
     }
@@ -78,11 +78,11 @@ public class TestRunnerUtil {
                 suites.add(new JUnit4TestReference(runner, runner.getDescription()));
             } catch (ClassNotFoundException ignored) {
                 String message = String.format("Failed to parse tests for suite %s. Details: %s.", classFqn, ignored.getMessage());
-                TestOutputSream.Instance().println(new TestReportItem(TestReportType.Error, null, null, message, ignored));
+                TestOutputSream.instance().println(new TestReportItem(TestReportType.Error, null, null, message, ignored));
             }
         }
         if (suites.isEmpty()) {
-            TestOutputSream.Instance().println(new TestReportItem(TestReportType.Error, null, null, "No test found to run.", null));
+            TestOutputSream.instance().println(new TestReportItem(TestReportType.Error, null, null, "No test found to run.", null));
             return emptyList();
         }
         return suites;

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestStream.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestStream.java
@@ -1,0 +1,7 @@
+package com.microsoft.java.test.runner;
+
+public interface TestStream {
+    void print(TestReportItem item);
+    void println(TestReportItem item);
+    void flush();
+}

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestingMessageHelper.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestingMessageHelper.java
@@ -224,51 +224,6 @@ public class TestingMessageHelper {
         TestReportItem item = new TestReportItem(TestReportType.Info, name, attrMap, null, null);
         return item;
     }
-    
-    /*private static String escape(String str) {
-    	if (str == null) {
-    		return str;
-    	}
-        int len = str.length();
-        StringBuilder sb = new StringBuilder(len);
-        String t;
-        for (int i = 0; i < len; i += 1) {
-            char c = str.charAt(i);
-            switch (c) {
-            case '\\':
-            case '\"':
-                sb.append('\\');
-                sb.append(c);
-                break;
-            case '\b':
-                sb.append("\\b");
-                break;
-            case '\t':
-                sb.append("\\t");
-                break;
-            case '\n':
-                sb.append("\\n");
-                break;
-            case '\f':
-                sb.append("\\f");
-                break;
-            case '\r':
-               sb.append("\\r");
-               break;
-            case '@':
-               sb.append("&#x40;");
-               break;
-            default:
-                if (c < ' ') {
-                    t = "000" + Integer.toHexString(c);
-                    sb.append("\\u" + t.substring(t.length() - 4));
-                } else {
-                    sb.append(c);
-                }
-            }
-        }
-        return sb.toString();
-    }*/
 
     private static class Pair {
         final String first;

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestingMessageHelper.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/TestingMessageHelper.java
@@ -16,11 +16,15 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
+
+import com.google.gson.Gson;
 
 public class TestingMessageHelper {
     private static final String TEST_REPORTER_ATTACHED = "testReporterAttached";
@@ -43,10 +47,10 @@ public class TestingMessageHelper {
     /**
      * Prints a message when the test reported was attached.
      *
-     * @param out output stream
+     * @param stream output stream
      */
-    public static void reporterAttached(PrintStream out) {
-        out.println(create(TEST_REPORTER_ATTACHED, (List<Pair>) null));
+    public static void reporterAttached(TestOutputSream stream) {
+        stream.println(create(TEST_REPORTER_ATTACHED, (List<Pair>) null));
     }
 
     /**
@@ -54,8 +58,8 @@ public class TestingMessageHelper {
      *
      * @param out output stream
      */
-    public static void rootPresentation(PrintStream out) {
-        out.println(create(ROOT_NAME, new Pair(NAME, "Default Suite")));
+    public static void rootPresentation(TestOutputSream stream) {
+        stream.println(create(ROOT_NAME, new Pair(NAME, "Default Suite")));
     }
 
     /**
@@ -64,13 +68,13 @@ public class TestingMessageHelper {
      * @param description information about test
      * @param out output stream
      */
-    public static void testStarted(PrintStream out, Description description) {
+    public static void testStarted(TestOutputSream stream, Description description) {
         String location = description.getClassName() + "." + description.getMethodName();
-        out.println(
+        stream.println(
                 create(
                         TEST_STARTED,
-                        new Pair(NAME, escape(description.getMethodName())),
-                        new Pair(LOCATION, "java:test://" + escape(location))));
+                        new Pair(NAME, description.getMethodName()),
+                        new Pair(LOCATION, "java:test://" + location)));
     }
 
     /**
@@ -79,8 +83,8 @@ public class TestingMessageHelper {
      * @param name method name
      * @param out output stream
      */
-    public static void testIgnored(PrintStream out, String name) {
-        out.println(create(TEST_IGNORED, new Pair(NAME, escape(name))));
+    public static void testIgnored(TestOutputSream stream, String name) {
+        stream.println(create(TEST_IGNORED, new Pair(NAME, name)));
     }
 
     /**
@@ -90,11 +94,11 @@ public class TestingMessageHelper {
      * @param out output stream
      * @param duration time of test running
      */
-    public static void testFinished(PrintStream out, Description description, long duration) {
-        out.println(
+    public static void testFinished(TestOutputSream stream, Description description, long duration) {
+        stream.println(
                 create(
                         TEST_FINISHED,
-                        new Pair(NAME, escape(description.getMethodName())),
+                        new Pair(NAME, description.getMethodName()),
                         new Pair(DURATION, String.valueOf(duration))));
     }
 
@@ -104,13 +108,13 @@ public class TestingMessageHelper {
      * @param description information about test node
      * @param out output stream
      */
-    public static void treeNode(PrintStream out, Description description) {
+    public static void treeNode(TestOutputSream stream, Description description) {
         String location = description.getClassName() + "." + description.getMethodName();
-        out.println(
+        stream.println(
                 create(
                         SUITE_TREE_NODE,
-                        new Pair(NAME, escape(description.getMethodName())),
-                        new Pair(LOCATION, "java:test://" + escape(location))));
+                        new Pair(NAME, description.getMethodName()),
+                        new Pair(LOCATION, "java:test://" + location)));
     }
 
     /**
@@ -119,8 +123,8 @@ public class TestingMessageHelper {
      * @param currentSuite name of test suite
      * @param out output stream
      */
-    public static void testSuiteFinished(PrintStream out, String currentSuite) {
-        out.println(create(TEST_SUITE_FINISHED, new Pair(NAME, escape(currentSuite))));
+    public static void testSuiteFinished(TestOutputSream stream, String currentSuite) {
+        stream.println(create(TEST_SUITE_FINISHED, new Pair(NAME, currentSuite)));
     }
 
     /**
@@ -129,12 +133,12 @@ public class TestingMessageHelper {
      * @param description information about suite
      * @param out output stream
      */
-    public static void testSuiteStarted(PrintStream out, Description description) {
-        out.println(
+    public static void testSuiteStarted(TestOutputSream stream, Description description) {
+        stream.println(
                 create(
                         TEST_SUITE_STARTED,
-                        new Pair(NAME, escape(description.getClassName())),
-                        new Pair(LOCATION, "java:test://" + escape(description.getClassName()))));
+                        new Pair(NAME, description.getClassName()),
+                        new Pair(LOCATION, "java:test://" + description.getClassName())));
     }
 
     /**
@@ -143,12 +147,12 @@ public class TestingMessageHelper {
      * @param description information about suite
      * @param out output stream
      */
-    public static void suiteTreeNodeStarted(PrintStream out, Description description) {
-        out.println(
+    public static void suiteTreeNodeStarted(TestOutputSream stream, Description description) {
+        stream.println(
                 create(
                         SUITE_TREE_STARTED,
-                        new Pair(NAME, escape(description.getClassName())),
-                        new Pair(LOCATION, "java:test://" + escape(description.getClassName()))));
+                        new Pair(NAME, description.getClassName()),
+                        new Pair(LOCATION, "java:test://" + description.getClassName())));
     }
 
     /**
@@ -157,12 +161,12 @@ public class TestingMessageHelper {
      * @param description information about suite
      * @param out output stream
      */
-    public static void suiteTreeNodeEnded(PrintStream out, Description description) {
-        out.println(
+    public static void suiteTreeNodeEnded(TestOutputSream stream, Description description) {
+        stream.println(
                 create(
                         SUITE_TREE_ENDED,
-                        new Pair(NAME, escape(description.getClassName())),
-                        new Pair(LOCATION, "java:test://" + escape(description.getClassName()))));
+                        new Pair(NAME, description.getClassName()),
+                        new Pair(LOCATION, "java:test://" + description.getClassName())));
     }
 
     /**
@@ -172,9 +176,9 @@ public class TestingMessageHelper {
      * @param failure describes the test that failed and the exception that was thrown
      * @param duration time of test running
      */
-    public static void testFailed(PrintStream out, Failure failure, long duration) {
+    public static void testFailed(TestOutputSream stream, Failure failure, long duration) {
         List<Pair> attributes = new ArrayList<>();
-        attributes.add(new Pair(NAME, escape(failure.getDescription().getMethodName())));
+        attributes.add(new Pair(NAME, failure.getDescription().getMethodName()));
         Throwable exception = failure.getException();
         if (exception != null) {
             String failMessage = failure.getMessage();
@@ -182,14 +186,14 @@ public class TestingMessageHelper {
             PrintWriter printWriter = new PrintWriter(writer);
             exception.printStackTrace(printWriter);
             String stackTrace = writer.getBuffer().toString();
-            attributes.add(new Pair(MESSAGE, escape(failMessage)));
-            attributes.add(new Pair(DETAILS, escape(stackTrace)));
+            attributes.add(new Pair(MESSAGE, failMessage));
+            attributes.add(new Pair(DETAILS, stackTrace));
         } else {
             attributes.add(new Pair(MESSAGE, ""));
         }
         attributes.add(new Pair(DURATION, String.valueOf(duration)));
 
-        out.println(create(TEST_FAILED, attributes));
+        stream.println(create(TEST_FAILED, attributes));
     }
 
     /**
@@ -198,13 +202,13 @@ public class TestingMessageHelper {
      * @param out output stream
      * @param result the summary of the test run, including all the tests that failed
      */
-    public static void testRunFinished(PrintStream out, Result result) {
-        out.printf(
-                "Total tests run: %d, Failures: %d, Skips: %d",
+    public static void testRunFinished(TestOutputSream stream, Result result) {
+        String message = String.format("Total tests run: %d, Failures: %d, Skips: %d",
                 result.getRunCount(), result.getFailureCount(), result.getIgnoreCount());
+        stream.println(new TestReportItem(TestReportType.Info, null, null, message, null));
     }
 
-    private static String create(String name, Pair... attributes) {
+    private static TestReportItem create(String name, Pair... attributes) {
         List<Pair> pairList = null;
         if (attributes != null) {
             pairList = Arrays.asList(attributes);
@@ -212,24 +216,16 @@ public class TestingMessageHelper {
         return create(name, pairList);
     }
 
-    private static String create(String name, List<Pair> attributes) {
-        StringBuilder builder = new StringBuilder("@@<{\"name\":");
-        builder.append('"').append(name).append('"');
+    private static TestReportItem create(String name, List<Pair> attributes) {
+        Map<String, String> attrMap = null;
         if (attributes != null) {
-            builder.append(", \"attributes\":{");
-            StringJoiner joiner = new StringJoiner(", ");
-            for (Pair attribute : attributes) {
-                joiner.add("\"" + attribute.first + "\":\"" + attribute.second + "\"");
-            }
-            builder.append(joiner.toString());
-            builder.append("}");
+            attrMap = attributes.stream().collect(Collectors.toMap((p) -> p.first, (p) -> p.second));
         }
-
-        builder.append("}>");
-        return builder.toString();
+        TestReportItem item = new TestReportItem(TestReportType.Info, name, attrMap, null, null);
+        return item;
     }
     
-    private static String escape(String str) {
+    /*private static String escape(String str) {
     	if (str == null) {
     		return str;
     	}
@@ -272,7 +268,7 @@ public class TestingMessageHelper {
             }
         }
         return sb.toString();
-    }
+    }*/
 
     private static class Pair {
         final String first;

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/listeners/CustomizedJUnitTestListener.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/listeners/CustomizedJUnitTestListener.java
@@ -11,6 +11,8 @@
 package com.microsoft.java.test.runner.listeners;
 
 import java.io.PrintStream;
+
+import com.microsoft.java.test.runner.TestOutputSream;
 import com.microsoft.java.test.runner.TestingMessageHelper;
 
 import org.junit.runner.Description;
@@ -19,18 +21,18 @@ import org.junit.runner.notification.Failure;
 
 /** Listener for whole life cycle of the JUnit test run. */
 public class CustomizedJUnitTestListener {
-    private final PrintStream out;
+    private final TestOutputSream stream;
 
     private long myCurrentTestStart;
 
     public CustomizedJUnitTestListener() {
-        this.out = System.out;
-        TestingMessageHelper.reporterAttached(out);
+        this.stream = TestOutputSream.Instance();
+        TestingMessageHelper.reporterAttached(stream);
     }
 
     /** Called before any tests have been run. */
     public void testRunStarted() {
-        TestingMessageHelper.rootPresentation(out);
+        TestingMessageHelper.rootPresentation(stream);
     }
 
     /**
@@ -42,7 +44,7 @@ public class CustomizedJUnitTestListener {
     public void testStarted(Description description) {
         myCurrentTestStart = System.currentTimeMillis();
 
-        TestingMessageHelper.testStarted(out, description);
+        TestingMessageHelper.testStarted(stream, description);
     }
 
     /**
@@ -53,7 +55,7 @@ public class CustomizedJUnitTestListener {
     public void testFinished(Description description) {
         long duration = System.currentTimeMillis() - myCurrentTestStart;
 
-        TestingMessageHelper.testFinished(out, description, duration);
+        TestingMessageHelper.testFinished(stream, description, duration);
     }
 
     /**
@@ -62,7 +64,7 @@ public class CustomizedJUnitTestListener {
      * @param description the description of the test suite
      */
     public void testSuiteStarted(Description description) {
-        TestingMessageHelper.testSuiteStarted(out, description);
+        TestingMessageHelper.testSuiteStarted(stream, description);
     }
 
     /**
@@ -71,7 +73,7 @@ public class CustomizedJUnitTestListener {
      * @param currentSuite name of test suite
      */
     public void testSuiteFinished(String currentSuite) {
-        TestingMessageHelper.testSuiteFinished(out, currentSuite);
+        TestingMessageHelper.testSuiteFinished(stream, currentSuite);
     }
 
     /**
@@ -82,7 +84,7 @@ public class CustomizedJUnitTestListener {
     public void testFailure(Failure failure) {
         long duration = System.currentTimeMillis() - myCurrentTestStart;
 
-        TestingMessageHelper.testFailed(out, failure, duration);
+        TestingMessageHelper.testFailed(stream, failure, duration);
     }
 
     /**
@@ -91,7 +93,7 @@ public class CustomizedJUnitTestListener {
      * @param result the summary of the test run, including all the tests that failed
      */
     public void testRunFinished(Result result) {
-        TestingMessageHelper.testRunFinished(out, result);
+        TestingMessageHelper.testRunFinished(stream, result);
     }
 
     /**
@@ -101,7 +103,7 @@ public class CustomizedJUnitTestListener {
      * @param description describes the test that will not be run
      */
     public void testIgnored(Description description) {
-        TestingMessageHelper.testIgnored(out, description.getMethodName());
+        TestingMessageHelper.testIgnored(stream, description.getMethodName());
     }
 
     /**
@@ -111,7 +113,7 @@ public class CustomizedJUnitTestListener {
      */
     public void suiteSendTree(Description description) {
         if (description.isTest()) {
-            TestingMessageHelper.treeNode(out, description);
+            TestingMessageHelper.treeNode(stream, description);
         } else {
             suiteTreeStarted(description);
             for (Description child : description.getChildren()) {
@@ -127,7 +129,7 @@ public class CustomizedJUnitTestListener {
      * @param description describes the test suite
      */
     public void suiteTreeStarted(Description description) {
-        TestingMessageHelper.suiteTreeNodeStarted(out, description);
+        TestingMessageHelper.suiteTreeNodeStarted(stream, description);
     }
 
     /**
@@ -136,6 +138,6 @@ public class CustomizedJUnitTestListener {
      * @param description describes the test suite
      */
     public void suiteTreeEnded(Description description) {
-        TestingMessageHelper.suiteTreeNodeEnded(out, description);
+        TestingMessageHelper.suiteTreeNodeEnded(stream, description);
     }
 }

--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/listeners/CustomizedJUnitTestListener.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/listeners/CustomizedJUnitTestListener.java
@@ -26,7 +26,7 @@ public class CustomizedJUnitTestListener {
     private long myCurrentTestStart;
 
     public CustomizedJUnitTestListener() {
-        this.stream = TestOutputSream.Instance();
+        this.stream = TestOutputSream.instance();
         TestingMessageHelper.reporterAttached(stream);
     }
 


### PR DESCRIPTION
Signed-off-by: xuzho <xuzho@microsoft.com>

the errors/info generated by the junit runner would be in a format like below:
Length + serialized json string