### PR TITLE
use photon because some API of org.eclipse.jdt.core is only available since 3.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <base.name>Java Test Runner</base.name>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tycho-version>1.0.0</tycho-version>
+        <tycho-version>1.2.0</tycho-version>
     </properties>
     <modules>
         <module>com.microsoft.java.test.plugin</module>
@@ -74,9 +74,9 @@
     </build>
     <repositories>
         <repository>
-            <id>oxygen</id>
+            <id>photon</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/releases/oxygen</url>
+            <url>http://download.eclipse.org/releases/photon</url>
         </repository>
         <repository>
             <id>oss.sonatype.org</id>


### PR DESCRIPTION
e.g. org.eclipse.jdt.core.IClasspathEntry.isTest is only available since 3.14.0, while oxygen's version is 3.13.0
Signed-off-by: xuzho <xuzho@microsoft.com>