### PR TITLE
Implement test explorer lazyload - TypeScript part

### DIFF
--- a/extension/src/Constants/commands.ts
+++ b/extension/src/Constants/commands.ts
@@ -39,6 +39,8 @@ export const JAVA_FETCH_TEST = 'vscode.java.test.fetch';
 
 export const JAVA_SEARCH_ALL_TESTS = 'vscode.java.test.search.all';
 
+export const JAVA_SEARCH_TEST_ENTRY = 'vscode.java.test.search.entries';
+
 export const JAVA_CALCULATE_CLASS_PATH = 'vscode.java.test.runtime.classpath';
 
 export const JAVA_GET_PROJECT_INFO = 'vscode.java.test.project.info';

--- a/extension/src/Explorer/testExplorer.ts
+++ b/extension/src/Explorer/testExplorer.ts
@@ -5,9 +5,10 @@ import * as path from 'path';
 import { window, workspace, Command, Event, EventEmitter, ExtensionContext, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri } from 'vscode';
 import { TestResourceManager } from '../testResourceManager';
 import * as Commands from '../Constants/commands';
-import { TestLevel, TestSuite } from '../Models/protocols';
+import { SearchResults, Test, TestSuite } from '../Models/protocols';
 import { RunConfigItem } from '../Models/testConfig';
 import { TestRunnerWrapper } from '../Runner/testRunnerWrapper';
+import * as FetchTestsUtility from '../Utils/fetchTestUtility';
 import { TestTreeNode, TestTreeNodeType } from './testTreeNode';
 
 export class TestExplorer implements TreeDataProvider<TestTreeNode> {
@@ -26,20 +27,47 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
 
     public getTreeItem(element: TestTreeNode): TreeItem {
         return {
-            label: this.getFriendlyElementName(element),
-            collapsibleState: element.isFolder ? TreeItemCollapsibleState.Collapsed : void 0,
+            label: element.name,
+            collapsibleState: element.isMethod ? TreeItemCollapsibleState.None : TreeItemCollapsibleState.Collapsed,
             command: this.getCommand(element),
             iconPath: this.getIconPath(element),
             contextValue: element.level.toString(),
         };
     }
 
-    public getChildren(element?: TestTreeNode): TestTreeNode[] | Thenable<TestTreeNode[]> {
-        if (element) {
+    public getChildren(element?: TestTreeNode): TestTreeNode[] | Promise<TestTreeNode[]> {
+        if (!element) {
+            const folders = workspace.workspaceFolders;
+            return folders.map((folder) => new TestTreeNode(folder.name, folder.name, TestTreeNodeType.Folder, folder.uri.toString()));
+        } else if (!element.children) {
+            return new Promise(async (resolve: (res: TestTreeNode[]) => void): Promise<void> => {
+                const results: SearchResults[] = await FetchTestsUtility.searchTestEntries({
+                    nodeType: element.level,
+                    uri: element.uri,
+                    fullName: element.fullName,
+                });
+                const parentSuite: TestSuite = this.toTestSuite(element);
+                if (parentSuite) {
+                    const childSuites: TestSuite[] = results.map((result) => result.suite);
+                    for (const childSuite of childSuites) {
+                        childSuite.parent = parentSuite;
+                    }
+                    parentSuite.children = childSuites;
+                    this.updateTestStorage(childSuites);
+                }
+                element.children = results.map((result) => new TestTreeNode(
+                    result.displayName,
+                    result.suite.test,
+                    result.nodeType,
+                    result.suite.uri,
+                    result.suite.range,
+                    element,
+                ));
+                resolve(element.children);
+            });
+        } else {
             return element.children;
         }
-        const tests: TestSuite[] = this._testCollectionStorage.getAll().filter((t) => t.level === TestLevel.Method);
-        return this.createTestTreeNode(tests, undefined, TestTreeNodeType.Folder);
     }
 
     public select(element: TestTreeNode) {
@@ -66,67 +94,20 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
         return element.children.map((c) => this.resolveTestSuites(c)).reduce((a, b) => a.concat(b));
     }
 
-    private createTestTreeNode(
-        tests: TestSuite[],
-        parent: TestTreeNode,
-        level: TestTreeNodeType): TestTreeNode[] {
-        if (level === TestTreeNodeType.Method) {
-            return tests.map((t) => new TestTreeNode(this.getShortName(t), t.uri, t.range, parent, undefined));
+    private updateTestStorage(tests: TestSuite[]) {
+        if (!tests || tests.length === 0) {
+            return;
         }
-        const keyFunc: (_: TestSuite) => string = this.getGroupKeyFunc(level);
-        const map = new Map<string, TestSuite[]>();
-        tests.forEach((t) => {
-            const key = keyFunc(t);
-            const collection: TestSuite[] = map.get(key);
-            if (!collection) {
-                map.set(key, [t]);
-            } else {
-                collection.push(t);
+        const groupByUri: {} = tests.reduce((accumulator, currentVal) => {
+            if (!accumulator[currentVal.uri]) {
+                accumulator[currentVal.uri] = [];
             }
-        });
-        const children = [...map.entries()].map((value) => {
-            const uri: string = level === TestTreeNodeType.Class ? value[1][0].uri : undefined;
-            const c: TestTreeNode = new TestTreeNode(value[0], uri, undefined, parent, undefined, level);
-            c.children = this.createTestTreeNode(value[1], c, level - 1);
-            return c;
-        });
-        return children;
-    }
-
-    private getGroupKeyFunc(level: TestTreeNodeType): ((_: TestSuite) => string) {
-        switch (level) {
-            case TestTreeNodeType.Folder:
-                return (_) => this.getWorkspaceFolder(_);
-            case TestTreeNodeType.Package:
-                return (_) => _.packageName;
-            case TestTreeNodeType.Class:
-                return (_) => this.getShortName(_.parent);
-            default:
-                throw new Error('Not supported group level');
+            accumulator[currentVal.uri].push(currentVal);
+            return accumulator;
+        }, {});
+        for (const uri of Object.keys(groupByUri)) {
+            this._testCollectionStorage.storeTests(Uri.parse(uri), groupByUri[uri]);
         }
-    }
-
-    private getWorkspaceFolder(test: TestSuite): string {
-        const folders = workspace.workspaceFolders;
-        return folders.filter((f) => {
-            const fp = Uri.parse(test.uri).fsPath;
-            return fp.startsWith(f.uri.fsPath);
-        }).map((f) => path.basename(f.uri.path))[0];
-    }
-
-    private getShortName(test: TestSuite): string {
-        if (test.level === TestLevel.Method) {
-            return test.test.substring(test.test.indexOf('#') + 1);
-        } else {
-            return test.test.substring(test.packageName === '' ? 0 : test.packageName.length + 1);
-        }
-    }
-
-    private getFriendlyElementName(element: TestTreeNode): string {
-        if (element.level === TestTreeNodeType.Package && element.name === '') {
-            return '(default package)';
-        }
-        return element.name;
     }
 
     private getIconPath(element: TestTreeNode): string | Uri | {dark: string | Uri, light: string | Uri} {
@@ -152,7 +133,7 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
     }
 
     private getCommand(element: TestTreeNode): Command | undefined {
-        if (element.level <= TestTreeNodeType.Class) {
+        if (element.level === TestTreeNodeType.Class || element.level === TestTreeNodeType.Method) {
             return {
                 command: Commands.JAVA_TEST_EXPLORER_SELECT,
                 title: '',
@@ -162,9 +143,9 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
         return undefined;
     }
 
-    private toTestSuite(element: TestTreeNode): TestSuite {
+    private toTestSuite(element: TestTreeNode): TestSuite | undefined {
         const uri: Uri = Uri.parse(element.uri);
-        const tests: TestSuite[] = this._testCollectionStorage.getTests(uri).tests;
-        return tests.filter((t) => t.test === element.fullName)[0];
+        const testData: Test | undefined = this._testCollectionStorage.getTests(uri);
+        return testData ? testData.tests.filter((t) => t.test === element.fullName)[0] : undefined;
     }
 }

--- a/extension/src/Explorer/testExplorer.ts
+++ b/extension/src/Explorer/testExplorer.ts
@@ -31,7 +31,7 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
             collapsibleState: element.isMethod ? TreeItemCollapsibleState.None : TreeItemCollapsibleState.Collapsed,
             command: this.getCommand(element),
             iconPath: this.getIconPath(element),
-            contextValue: element.level.toString(),
+            contextValue: element.type.toString(),
         };
     }
 
@@ -42,7 +42,7 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
         } else if (!element.children) {
             return new Promise(async (resolve: (res: TestTreeNode[]) => void): Promise<void> => {
                 const results: SearchResults[] = await FetchTestsUtility.searchTestEntries({
-                    nodeType: element.level,
+                    nodeType: element.type,
                     uri: element.uri,
                     fullName: element.fullName,
                 });
@@ -88,7 +88,7 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
         if (!element) {
             return (this.getChildren(element) as TestTreeNode[]).map((f) => this.resolveTestSuites(f)).reduce((a, b) => a.concat(b));
         }
-        if (element.level === TestTreeNodeType.Class || element.level === TestTreeNodeType.Method) {
+        if (element.type === TestTreeNodeType.Class || element.type === TestTreeNodeType.Method) {
             return[this.toTestSuite(element)];
         }
         return element.children.map((c) => this.resolveTestSuites(c)).reduce((a, b) => a.concat(b));
@@ -111,7 +111,7 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
     }
 
     private getIconPath(element: TestTreeNode): string | Uri | {dark: string | Uri, light: string | Uri} {
-        switch (element.level) {
+        switch (element.type) {
             case TestTreeNodeType.Method:
             return {
                 dark: this._context.asAbsolutePath(path.join('resources', 'media', 'dark', 'method.svg')),
@@ -133,7 +133,7 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
     }
 
     private getCommand(element: TestTreeNode): Command | undefined {
-        if (element.level === TestTreeNodeType.Class || element.level === TestTreeNodeType.Method) {
+        if (element.type === TestTreeNodeType.Class || element.type === TestTreeNodeType.Method) {
             return {
                 command: Commands.JAVA_TEST_EXPLORER_SELECT,
                 title: '',

--- a/extension/src/Explorer/testExplorer.ts
+++ b/extension/src/Explorer/testExplorer.ts
@@ -39,35 +39,35 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
         if (!element) {
             const folders = workspace.workspaceFolders;
             return folders.map((folder) => new TestTreeNode(folder.name, folder.name, TestTreeNodeType.Folder, folder.uri.toString()));
-        } else if (!element.children) {
-            return new Promise(async (resolve: (res: TestTreeNode[]) => void): Promise<void> => {
-                const results: SearchResults[] = await FetchTestsUtility.searchTestEntries({
-                    nodeType: element.type,
-                    uri: element.uri,
-                    fullName: element.fullName,
-                });
-                const parentSuite: TestSuite = this.toTestSuite(element);
-                if (parentSuite) {
-                    const childSuites: TestSuite[] = results.map((result) => result.suite);
-                    for (const childSuite of childSuites) {
-                        childSuite.parent = parentSuite;
-                    }
-                    parentSuite.children = childSuites;
-                    this.updateTestStorage(childSuites);
-                }
-                element.children = results.map((result) => new TestTreeNode(
-                    result.displayName,
-                    result.suite.test,
-                    result.nodeType,
-                    result.suite.uri,
-                    result.suite.range,
-                    element,
-                ));
-                resolve(element.children);
-            });
-        } else {
+        } else if (element.children) {
             return element.children;
         }
+
+        return new Promise(async (resolve: (res: TestTreeNode[]) => void): Promise<void> => {
+            const results: SearchResults[] = await FetchTestsUtility.searchTestEntries({
+                nodeType: element.type,
+                uri: element.uri,
+                fullName: element.fullName,
+            });
+            const parentSuite: TestSuite = this.toTestSuite(element);
+            if (parentSuite) {
+                const childSuites: TestSuite[] = results.map((result) => result.suite);
+                for (const childSuite of childSuites) {
+                    childSuite.parent = parentSuite;
+                }
+                parentSuite.children = childSuites;
+                this.updateTestStorage(childSuites);
+            }
+            element.children = results.map((result) => new TestTreeNode(
+                result.displayName,
+                result.suite.test,
+                result.nodeType,
+                result.suite.uri,
+                result.suite.range,
+                element,
+            ));
+            resolve(element.children);
+        });
     }
 
     public select(element: TestTreeNode) {

--- a/extension/src/Explorer/testTreeNode.ts
+++ b/extension/src/Explorer/testTreeNode.ts
@@ -6,11 +6,12 @@ import { Range } from 'vscode';
 export class TestTreeNode {
     constructor(
         private _name: string,
+        private _fullName: string,
+        private _level: TestTreeNodeType,
         private _uri?: string,
         private _range?: Range,
         private _parent?: TestTreeNode,
-        private _children?: TestTreeNode[],
-        private _level: TestTreeNodeType = TestTreeNodeType.Method) {
+        private _children?: TestTreeNode[]) {
     }
 
     public get name(): string {
@@ -18,11 +19,7 @@ export class TestTreeNode {
     }
 
     public get fullName(): string {
-        const prefix: string = this._parent && this._parent.level !== TestTreeNodeType.Folder ? `${this._parent.fullName}` : '';
-        if (prefix === '') {
-            return this._name;
-        }
-        return prefix + (this.level === TestTreeNodeType.Method ? '#' : '.') + this._name;
+        return this._fullName;
     }
 
     public get uri(): string {
@@ -33,8 +30,8 @@ export class TestTreeNode {
         return this._range;
     }
 
-    public get isFolder(): boolean {
-        return this.level !== TestTreeNodeType.Method;
+    public get isMethod(): boolean {
+        return this.level === TestTreeNodeType.Method;
     }
 
     public get children(): TestTreeNode[] {
@@ -59,8 +56,8 @@ export class TestTreeNode {
 }
 
 export enum TestTreeNodeType {
-    Method,
-    Class,
-    Package,
-    Folder,
+    Method = 0,
+    Class = 1,
+    Package = 2,
+    Folder = 3,
 }

--- a/extension/src/Explorer/testTreeNode.ts
+++ b/extension/src/Explorer/testTreeNode.ts
@@ -7,7 +7,7 @@ export class TestTreeNode {
     constructor(
         private _name: string,
         private _fullName: string,
-        private _level: TestTreeNodeType,
+        private _type: TestTreeNodeType,
         private _uri?: string,
         private _range?: Range,
         private _parent?: TestTreeNode,
@@ -31,7 +31,7 @@ export class TestTreeNode {
     }
 
     public get isMethod(): boolean {
-        return this.level === TestTreeNodeType.Method;
+        return this.type === TestTreeNodeType.Method;
     }
 
     public get children(): TestTreeNode[] {
@@ -50,8 +50,8 @@ export class TestTreeNode {
         this._parent = c;
     }
 
-    public get level(): TestTreeNodeType {
-        return this._level;
+    public get type(): TestTreeNodeType {
+        return this._type;
     }
 }
 

--- a/extension/src/Models/protocols.ts
+++ b/extension/src/Models/protocols.ts
@@ -2,10 +2,23 @@
 // Licensed under the MIT license.
 
 import { Range } from 'vscode';
+import { TestTreeNodeType } from '../Explorer/testTreeNode';
 
 export type Test = {
     tests: TestSuite[];
     dirty: boolean;
+};
+
+export type SearchRequest = {
+    nodeType: TestTreeNodeType;
+    uri: string;
+    fullName: string;
+};
+
+export type SearchResults = {
+    suite: TestSuite;
+    displayName: string;
+    nodeType: TestTreeNodeType;
 };
 
 export type TestSuite = {

--- a/extension/src/Utils/fetchTestUtility.ts
+++ b/extension/src/Utils/fetchTestUtility.ts
@@ -3,7 +3,7 @@
 
 import { TextDocument } from 'vscode';
 import * as Commands from '../Constants/commands';
-import { TestSuite } from '../Models/protocols';
+import { SearchRequest, SearchResults, TestSuite } from '../Models/protocols';
 
 export function fetchTests(document: TextDocument): Thenable<TestSuite[]> {
     return Commands.executeJavaLanguageServerCommand(Commands.JAVA_FETCH_TEST, document.uri.toString()).then((tests: TestSuite[]) => {
@@ -13,6 +13,11 @@ export function fetchTests(document: TextDocument): Thenable<TestSuite[]> {
     (reason) => {
         return Promise.reject(reason);
     });
+}
+
+export async function searchTestEntries(request: SearchRequest): Promise<SearchResults[]> {
+    const serialized: string = JSON.stringify(request);
+    return Commands.executeJavaLanguageServerCommand<SearchResults[]>(Commands.JAVA_SEARCH_TEST_ENTRY, serialized);
 }
 
 export function searchAllTests(): Thenable<any> {

--- a/extension/src/testResourceManager.ts
+++ b/extension/src/testResourceManager.ts
@@ -26,7 +26,6 @@ export class TestResourceManager {
             tests,
         };
         this.testsIndexedByFileUri.set(path, test);
-        this._onDidChangeTestStorage.fire();
     }
     public removeTests(file: Uri): void {
         const path = file.fsPath || '';


### PR DESCRIPTION
This PR is to reimplement the Test explorer: using lazy load strategy. #259 

GIF: 
![lazyload](https://user-images.githubusercontent.com/6193897/45273330-cc6c6880-b4e4-11e8-840e-bd2c7828129a.gif)

Future tasks:
- Currently, we wrap the `TestSuite` into the `SearchResult`, we should consider simplifying the protocol in the future.