### PR TITLE
Support for JUnit 5's DisplayName

### DIFF
--- a/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
+++ b/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
@@ -38,7 +38,7 @@ public class JUnit4TestSearcher extends BaseFrameworkSearcher {
             if (!Flags.isPublic(flags)) {
                 return false;
             }
-            return super.isTestMethod(method) && TestSearchUtils.hasTestAnnotation(method, TEST_METHOD_ANNOTATION);
+            return super.isTestMethod(method) && TestSearchUtils.hasAnnotation(method, TEST_METHOD_ANNOTATION);
         } catch (final JavaModelException e) {
             // ignore
             return false;

--- a/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
+++ b/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
@@ -31,6 +31,6 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
 
     @Override
     public boolean isTestMethod(IMethod method) {
-        return super.isTestMethod(method) && TestSearchUtils.hasTestAnnotation(method, TEST_METHOD_ANNOTATION);
+        return super.isTestMethod(method) && TestSearchUtils.hasAnnotation(method, TEST_METHOD_ANNOTATION);
     }
 }

--- a/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
+++ b/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
@@ -31,6 +31,6 @@ public class TestNGTestSearcher extends BaseFrameworkSearcher {
 
     @Override
     public boolean isTestMethod(IMethod method) {
-        return super.isTestMethod(method) && TestSearchUtils.hasTestAnnotation(method, TEST_METHOD_ANNOTATION);
+        return super.isTestMethod(method) && TestSearchUtils.hasAnnotation(method, TEST_METHOD_ANNOTATION);
     }
 }

--- a/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -241,7 +241,7 @@ public class TestSearchUtils {
             throws JavaModelException {
         String displayName = element.getElementName();
         if (kind == TestKind.JUnit5 && element instanceof IMethod) {
-            Optional<IAnnotation> annotation = getAnnotation((IMethod) element, DISPLAY_NAME_ANNOTATION_JUNIT5);
+            final Optional<IAnnotation> annotation = getAnnotation((IMethod) element, DISPLAY_NAME_ANNOTATION_JUNIT5);
             if (annotation.isPresent()) {
                 displayName = (String) annotation.get().getMemberValuePairs()[0].getValue();
             }
@@ -277,10 +277,11 @@ public class TestSearchUtils {
             final String[][] fullNameArr = method.getDeclaringType().resolveType(name);
             if (fullNameArr == null) {
                 final ICompilationUnit cu = method.getCompilationUnit();
-                if (cu != null && cu.getImport(methodAnnotation).exists())
+                if (cu != null && cu.getImport(methodAnnotation).exists()) {
                     return Optional.of(annotation);
-                else
+                } else {
                     return Optional.empty();
+                }
             }
             final String fullName = Arrays.stream(fullNameArr[0]).collect(Collectors.joining("."));
             return fullName.equals(methodAnnotation) ?


### PR DESCRIPTION
This PR reads JUnit 5's `@DisplayName` annotation and shows it in the side bar instead of the method names:

![screenshot](https://user-images.githubusercontent.com/9693842/47722299-66819f00-dc52-11e8-85ef-26e5bcf8ba57.png)
