### PR TITLE
Add test result manager

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -9,6 +9,7 @@ import { JavaTestRunnerCommands } from './constants/commands';
 import { explorerNodeManager } from './explorer/explorerNodeManager';
 import { testExplorer } from './explorer/testExplorer';
 import { TestTreeNode } from './explorer/TestTreeNode';
+import { testResultManager } from './testResultManager';
 import { testStatusBarProvider } from './testStatusBarProvider';
 
 export async function activate(context: ExtensionContext): Promise<void> {
@@ -42,6 +43,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
         window.registerTreeDataProvider(testExplorer.testExplorerViewId, testExplorer),
         explorerNodeManager,
         testStatusBarProvider,
+        testResultManager,
         watcher,
         languages.registerCodeLensProvider('java', testCodeLensProvider),
         instrumentAndRegisterCommand(JavaTestRunnerCommands.OPEN_DOCUMENT_FOR_NODE, async (node: TestTreeNode) => await openTextDocumentForNode(node)),

--- a/extension/src/testResultManager.ts
+++ b/extension/src/testResultManager.ts
@@ -5,7 +5,7 @@ import { Disposable, Uri } from 'vscode';
 import { ITestResult, ITestResultDetails } from './runners/models';
 
 class TestResultManager implements Disposable {
-    private testResultMap: Map<string, IResultsInUri> = new Map<string, IResultsInUri>();
+    private testResultMap: Map<string, IResultsInFsPath> = new Map<string, IResultsInFsPath>();
 
     public storeResult(...results: ITestResult[]): void {
         for (const result of results) {
@@ -21,9 +21,9 @@ class TestResultManager implements Disposable {
     }
 
     public getResult(fsPath: string, testFullName: string): ITestResultDetails | undefined {
-        const resultsInUri: IResultsInUri | undefined = this.testResultMap.get(fsPath);
-        if (resultsInUri) {
-            return resultsInUri.methodsMap.get(testFullName);
+        const resultsInFsPath: IResultsInFsPath | undefined = this.testResultMap.get(fsPath);
+        if (resultsInFsPath) {
+            return resultsInFsPath.methodsMap.get(testFullName);
         }
         return undefined;
     }
@@ -37,7 +37,7 @@ class TestResultManager implements Disposable {
     }
 }
 
-interface IResultsInUri {
+interface IResultsInFsPath {
     methodsMap: Map<string, ITestResultDetails>;
     isDirty: boolean;
 }

--- a/extension/src/testResultManager.ts
+++ b/extension/src/testResultManager.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { Disposable, Uri } from 'vscode';
+import { ITestResult, ITestResultDetails } from './runners/models';
+
+class TestResultManager implements Disposable {
+    private testResultMap: Map<string, IResultsInUri> = new Map<string, IResultsInUri>();
+
+    public storeResult(...results: ITestResult[]): void {
+        for (const result of results) {
+            const fsPath: string = Uri.parse(result.uri).fsPath;
+            if (!this.testResultMap.has(fsPath)) {
+                this.testResultMap.set(fsPath, {
+                    methodsMap: new Map<string, ITestResultDetails>(),
+                    isDirty: false,
+                });
+            }
+            this.testResultMap.get(fsPath)!.methodsMap.set(result.fullName, result.result);
+        }
+    }
+
+    public getResult(fsPath: string, testFullName: string): ITestResultDetails | undefined {
+        const resultsInUri: IResultsInUri | undefined = this.testResultMap.get(fsPath);
+        if (resultsInUri) {
+            return resultsInUri.methodsMap.get(testFullName);
+        }
+        return undefined;
+    }
+
+    public hasResultWithUri(uriString: string): boolean {
+        return this.testResultMap.has(uriString);
+    }
+
+    public dispose(): void {
+        this.testResultMap.clear();
+    }
+}
+
+interface IResultsInUri {
+    methodsMap: Map<string, ITestResultDetails>;
+    isDirty: boolean;
+}
+
+export const testResultManager: TestResultManager = new TestResultManager();


### PR DESCRIPTION
The test result manager is used to store the test result. It will be consumed by the test report.

The data structure is

`fsPath` -> `IResultsInFsPath`: all the results in this fsPath.

`IResultsInFsPath` is a map, the key is all the methods name.

`methodName` -> results of this method