### PR TITLE
Add way to disable test and debug code lens provider

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -6,7 +6,7 @@
 
 A lightweight extension to run and debug Java test cases in Visual Studio Code. It works with [Language Support for Java by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java) and [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) to provide the following features:
 
-- Support JUnit (v4.8.0+) test cases 
+- Support JUnit (v4.8.0+) test cases
 - Run test cases
 - Debug test cases
 - View test logs
@@ -28,6 +28,7 @@ A lightweight extension to run and debug Java test cases in Visual Studio Code. 
 ## Supported VSCode settings
 
 - `java.test.report.position`: Specify where to show the test report. Supported values are `sideView`, `currentView`. The default value is `sideView`.
+- `java.test.settings.enableTestCodeLens`: enable the code lens provider for the test and debug buttons over test entry points, defaults to `true`.
 
 ## Requirements
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -28,7 +28,7 @@ A lightweight extension to run and debug Java test cases in Visual Studio Code. 
 ## Supported VSCode settings
 
 - `java.test.report.position`: Specify where to show the test report. Supported values are `sideView`, `currentView`. The default value is `sideView`.
-- `java.test.settings.enableTestCodeLens`: enable the code lens provider for the test and debug buttons over test entry points, defaults to `true`.
+- `java.test.settings.enableTestCodeLens`: Enable the code lens provider for the test and debug buttons over test entry points, defaults to `true`.
 
 ## Requirements
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -190,6 +190,11 @@
                     "default": "sideView",
                     "description": "Specify where to show the test report",
                     "scope": "window"
+                },
+                "java.test.settings.enableTestCodeLens": {
+                    "type": "boolean",
+                    "description": "Enable the test code lens providers over test methods.",
+                    "default": true
                 }
             }
         }

--- a/extension/package.json
+++ b/extension/package.json
@@ -193,7 +193,7 @@
                 },
                 "java.test.settings.enableTestCodeLens": {
                     "type": "boolean",
-                    "description": "Enable the test code lens providers over test methods.",
+                    "description": "Enable the test code lens providers over test methods and classes.",
                     "default": true
                 }
             }

--- a/extension/src/codeLensContainer.ts
+++ b/extension/src/codeLensContainer.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { ConfigurationChangeEvent, Disposable, languages, workspace, WorkspaceConfiguration } from 'vscode';
+import { testCodeLensProvider } from './codeLensProvider';
+
+const JAVA_TEST_SETTINGS_CONFIGURATION: string = 'java.test.settings';
+const ENABLE_CODE_LENS_VARIABLE: string = 'enableTestCodeLens';
+const LANGUAGE: string = 'java';
+
+class TestCodeLensContainer implements Disposable {
+  private lensProvider: Disposable | undefined;
+  private configurationEvent: Disposable;
+
+  constructor() {
+    const configuration: WorkspaceConfiguration = workspace.getConfiguration(JAVA_TEST_SETTINGS_CONFIGURATION);
+    const isCodeLenseEnabled: boolean | undefined = configuration.get<boolean>(ENABLE_CODE_LENS_VARIABLE);
+    if (isCodeLenseEnabled) {
+        this.lensProvider = languages.registerCodeLensProvider(LANGUAGE, testCodeLensProvider);
+    }
+
+    this.configurationEvent = workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
+      if (event.affectsConfiguration(JAVA_TEST_SETTINGS_CONFIGURATION)) {
+        const newConfiguration: WorkspaceConfiguration = workspace.getConfiguration(JAVA_TEST_SETTINGS_CONFIGURATION);
+        const newEnabled: boolean | undefined = newConfiguration.get<boolean>(ENABLE_CODE_LENS_VARIABLE);
+        if (newEnabled && this.lensProvider === undefined) {
+            this.lensProvider = languages.registerCodeLensProvider(LANGUAGE, testCodeLensProvider);
+        } else if (!newEnabled && this.lensProvider !== undefined) {
+            this.lensProvider.dispose();
+            this.lensProvider = undefined;
+        }
+    }
+    }, this);
+  }
+
+  public dispose(): void {
+    if (this.lensProvider !== undefined) {
+        this.lensProvider.dispose();
+    }
+    this.configurationEvent.dispose();
+  }
+}
+
+export const testCodeLensContainer: TestCodeLensContainer = new TestCodeLensContainer();

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { commands, Disposable, Extension, ExtensionContext, extensions, FileSystemWatcher, languages, TextDocument, Uri, window, workspace } from 'vscode';
+import { commands, Disposable, Extension, ExtensionContext, extensions, FileSystemWatcher, TextDocument, Uri, window, workspace } from 'vscode';
 import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentOperation } from 'vscode-extension-telemetry-wrapper';
-import { testCodeLensProvider } from './codeLensProvider';
+import { testCodeLensContainer } from './codeLensContainer';
 import { debugTests, runTests } from './commands/executeTests';
 import { debugTestsFromExplorer, debugTestsWithFromExplorer, openTextDocumentForNode, runTestsFromExplorer, runTestsWithConfigFromExplorer } from './commands/explorerCommands';
 import { showReport } from './commands/reportCommands';
@@ -74,7 +74,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
         testReportProvider,
         watcher,
         testOutputChannel,
-        languages.registerCodeLensProvider('java', testCodeLensProvider),
+        testCodeLensContainer,
         workspace.registerTextDocumentContentProvider(testReportProvider.scheme, testReportProvider),
         instrumentAndRegisterCommand(JavaTestRunnerCommands.OPEN_DOCUMENT_FOR_NODE, async (node: TestTreeNode) => await openTextDocumentForNode(node)),
         instrumentAndRegisterCommand(JavaTestRunnerCommands.REFRESH_EXPLORER, (node: TestTreeNode) => testExplorer.refresh(node)),


### PR DESCRIPTION
There are cases where the tests by default do not work correctly, and
the launch.test.json is not configurable enough to work trivially with
some of my projects (mainly JNI projects). I have had a large amount of
users get confused why these buttons don't work, and attempts at using
the launch.test.json file don't work either. I provided this same PR to
the debug extension as well.