### PR TITLE
Rename request to params

### DIFF
--- a/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/SearchTestItemParams.java
+++ b/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/SearchTestItemParams.java
@@ -11,7 +11,7 @@
 
 package com.microsoft.java.test.plugin.model;
 
-public class SearchChildrenNodeRequest {
+public class SearchTestItemParams {
     private TestLevel level;
 
     private String uri;

--- a/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -12,7 +12,7 @@
 package com.microsoft.java.test.plugin.util;
 
 import com.google.gson.Gson;
-import com.microsoft.java.test.plugin.model.SearchChildrenNodeRequest;
+import com.microsoft.java.test.plugin.model.SearchTestItemParams;
 import com.microsoft.java.test.plugin.model.TestItem;
 import com.microsoft.java.test.plugin.model.TestKind;
 import com.microsoft.java.test.plugin.model.TestLevel;
@@ -80,14 +80,14 @@ public class TestSearchUtils {
             return Collections.<TestItem>emptyList();
         }
         final Gson gson = new Gson();
-        final SearchChildrenNodeRequest request = gson.fromJson((String) arguments.get(0),
-                SearchChildrenNodeRequest.class);
+        final SearchTestItemParams params = gson.fromJson((String) arguments.get(0),
+                SearchTestItemParams.class);
         final List<TestItem> resultList = new ArrayList<>();
-        final TestItemSearcher[] searchers = searcherMap.get(request.getLevel());
+        final TestItemSearcher[] searchers = searcherMap.get(params.getLevel());
         if (searchers != null) {
             for (final TestItemSearcher searcher : searchers) {
                 try {
-                    resultList.addAll(searcher.search(request.getUri(), request.getFullName(), monitor));
+                    resultList.addAll(searcher.search(params.getUri(), params.getFullName(), monitor));
                 } catch (final Exception e) {
                     // swallow the exceptions
                     e.printStackTrace();

--- a/extension/src/explorer/testExplorer.ts
+++ b/extension/src/explorer/testExplorer.ts
@@ -4,9 +4,9 @@
 import * as path from 'path';
 import { Command, Event, EventEmitter, ExtensionContext, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri, workspace, WorkspaceFolder } from 'vscode';
 import { JavaTestRunnerCommands } from '../constants/commands';
-import { ISearchChildrenNodeParams, ITestItem, TestLevel } from '../protocols';
+import { ISearchTestItemParams, ITestItem, TestLevel } from '../protocols';
 import { searchTestItems } from '../utils/commandUtils';
-import { constructSearchChildrenNodeRequest } from '../utils/protocolUtils';
+import { constructSearchTestItemParams } from '../utils/protocolUtils';
 import { explorerNodeManager } from './explorerNodeManager';
 import { TestTreeNode } from './TestTreeNode';
 
@@ -55,8 +55,8 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
     }
 
     private async getChildrenOfTreeNode(element: TestTreeNode): Promise<TestTreeNode[]> {
-        const requestString: ISearchChildrenNodeParams = constructSearchChildrenNodeRequest(element);
-        const results: ITestItem[] = await searchTestItems(requestString);
+        const searchParams: ISearchTestItemParams = constructSearchTestItemParams(element);
+        const results: ITestItem[] = await searchTestItems(searchParams);
         return results.map((result: ITestItem) => new TestTreeNode(
             result.displayName,
             result.fullName,

--- a/extension/src/protocols.ts
+++ b/extension/src/protocols.ts
@@ -18,7 +18,7 @@ export interface ITestItem extends ITestItemBase {
     level: TestLevel;
 }
 
-export interface ISearchChildrenNodeParams {
+export interface ISearchTestItemParams {
     level: TestLevel;
     fullName: string;
     uri: string;

--- a/extension/src/utils/commandUtils.ts
+++ b/extension/src/utils/commandUtils.ts
@@ -3,11 +3,11 @@
 
 import { commands, Uri } from 'vscode';
 import { JavaLanguageServerCommands, JavaTestRunnerDelegateCommands } from '../constants/commands';
-import { IProjectInfo, ISearchChildrenNodeParams, ITestItem } from '../protocols';
+import { IProjectInfo, ISearchTestItemParams, ITestItem } from '../protocols';
 
-export async function searchTestItems(request: ISearchChildrenNodeParams): Promise<ITestItem[]> {
+export async function searchTestItems(params: ISearchTestItemParams): Promise<ITestItem[]> {
     return await executeJavaLanguageServerCommand<ITestItem[]>(
-        JavaTestRunnerDelegateCommands.SEARCH_TEST_ITEMS, JSON.stringify(request)) || [];
+        JavaTestRunnerDelegateCommands.SEARCH_TEST_ITEMS, JSON.stringify(params)) || [];
 }
 
 export async function searchTestCodeLens(uri: string): Promise<ITestItem[]> {

--- a/extension/src/utils/protocolUtils.ts
+++ b/extension/src/utils/protocolUtils.ts
@@ -3,9 +3,9 @@
 
 import { Uri } from 'vscode';
 import { TestTreeNode } from '../explorer/TestTreeNode';
-import { ISearchChildrenNodeParams } from '../protocols';
+import { ISearchTestItemParams } from '../protocols';
 
-export function constructSearchChildrenNodeRequest(node: TestTreeNode): ISearchChildrenNodeParams {
+export function constructSearchTestItemParams(node: TestTreeNode): ISearchTestItemParams {
     return {
         uri: Uri.file(node.fsPath).toString(),
         level: node.level,


### PR DESCRIPTION
Rename the `XXXXRequest` to `XXXXParams` to make the name for suitable