### PR TITLE
Fix the bug that cannot find out TestNG test items which do not have public signature

### DIFF
--- a/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
+++ b/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
@@ -14,9 +14,7 @@ package com.microsoft.java.test.plugin.searcher;
 import com.microsoft.java.test.plugin.model.TestKind;
 import com.microsoft.java.test.plugin.util.TestSearchUtils;
 
-import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.JavaModelException;
 
 public class TestNGTestSearcher extends BaseFrameworkSearcher {
 
@@ -33,15 +31,6 @@ public class TestNGTestSearcher extends BaseFrameworkSearcher {
 
     @Override
     public boolean isTestMethod(IMethod method) {
-        try {
-            final int flags = method.getFlags();
-            if (!Flags.isPublic(flags)) {
-                return false;
-            }
-            return super.isTestMethod(method) && TestSearchUtils.hasTestAnnotation(method, TEST_METHOD_ANNOTATION);
-        } catch (final JavaModelException e) {
-            // ignore
-            return false;
-        }
+        return super.isTestMethod(method) && TestSearchUtils.hasTestAnnotation(method, TEST_METHOD_ANNOTATION);
     }
 }

--- a/extension/src/runners/runnerExecutor.ts
+++ b/extension/src/runners/runnerExecutor.ts
@@ -103,6 +103,10 @@ class RunnerExecutor {
     private mapTestsByProjectAndKind(tests: ITestItem[]): Map<string, ITestItem[]> {
         const map: Map<string, ITestItem[]> = new Map<string, ITestItem[]>();
         for (const test of tests) {
+            if (!test.kind) {
+                testOutputChannel.error(`Unkonwn kind of test item: ${test.fullName}`);
+                continue;
+            }
             const key: string = test.project.concat(test.kind.toString());
             const testArray: ITestItem[] | undefined = map.get(key);
             if (testArray) {


### PR DESCRIPTION
Fix #407 

TestNG test method does not restrict that it must have the public signature.