### PR TITLE
Disable generating the test-output folder when running TestNG tests

### DIFF
--- a/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/testng/TestNGRunner.java
+++ b/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/testng/TestNGRunner.java
@@ -31,6 +31,7 @@ public class TestNGRunner {
         createTests(map, suite);
 
         final TestNG testNG = new TestNG();
+        testNG.setUseDefaultListeners(false);
         final ITestListener listener = new TestNGListener();
         testNG.addListener(listener);
         testNG.setXmlSuites(Collections.singletonList(suite));


### PR DESCRIPTION
Fix #416 

Reference: https://stackoverflow.com/a/38245000