### PR TITLE
Fix the bug that workingDirectory is not generated in launch.test.json

### DIFF
--- a/extension/src/protocols.ts
+++ b/extension/src/protocols.ts
@@ -24,7 +24,7 @@ export interface ISearchTestItemParams {
 }
 
 export interface IProjectInfo {
-    path: Uri;
+    path: string;
     name: string;
 }
 

--- a/extension/src/protocols.ts
+++ b/extension/src/protocols.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { Range, Uri } from 'vscode';
+import { Range } from 'vscode';
 
 export interface ITestItemBase {
     fullName: string;

--- a/extension/src/testConfigManager.ts
+++ b/extension/src/testConfigManager.ts
@@ -50,7 +50,7 @@ class TestConfigManager {
                     return {
                         name: project.name,
                         projectName: project.name,
-                        workingDirectory: project.path.fsPath,
+                        workingDirectory: Uri.parse(project.path).fsPath,
                         args: [],
                         vmargs: [],
                         env: {},
@@ -64,7 +64,7 @@ class TestConfigManager {
                     return {
                         name: project.name,
                         projectName: project.name,
-                        workingDirectory: project.path.fsPath,
+                        workingDirectory: Uri.parse(project.path).fsPath,
                         args: [],
                         vmargs: [],
                         env: {},


### PR DESCRIPTION
Since it's returned from LS, the type should be string.

Fix #431 