### PR TITLE
Stop clipping the EOL when parsing the runner output

### DIFF
--- a/java-extension/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/common/TestOutputStream.java
+++ b/java-extension/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/common/TestOutputStream.java
@@ -59,8 +59,10 @@ public class TestOutputStream implements TestStream {
         final String content = toJson(item);
         if (item.type == TestMessageType.Error) {
             this.err.println(content);
+            this.err.println();
         } else {
             this.out.println(content);
+            this.out.println();
         }
     }
 

--- a/src/runners/baseRunner/BaseRunner.ts
+++ b/src/runners/baseRunner/BaseRunner.ts
@@ -76,7 +76,7 @@ export abstract class BaseRunner implements ITestRunner {
                 const index: number = buffer.lastIndexOf(os.EOL);
                 if (index >= 0) {
                     testResultAnalyzer.analyzeData(buffer.substring(0, index));
-                    buffer = buffer.substring(index + os.EOL.length);
+                    buffer = buffer.substring(index);
                 }
             });
             this.process.on('close', (signal: number) => {


### PR DESCRIPTION
This is the first part of the work for issue #505 