### PR TITLE
Maven extension is required for Test Runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You can find the following commands in the Command Palette (<kbd>**F1**</kbd> / 
 - VS Code (version 1.23.0 or later)
 - [Language Support for Java by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java)
 - [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)
+- [Maven for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-maven)
 
 ## Feedback and Questions
 


### PR DESCRIPTION
If Maven for Java extension is not required, then this extension needs proper documentation on how to use it on a non-Maven project, such as a plain project created by the Java Dependency Viewer extension.

// @hexiaokai 