### PR TITLE
Support to set the default configuration name

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
         "onCommand:java.test.explorer.select",
         "onCommand:java.test.explorer.run",
         "onCommand:java.test.explorer.debug",
-        "onCommand:java.test.explorer.run.config",
-        "onCommand:java.test.explorer.debug.config",
         "onCommand:java.test.run",
         "onCommand:java.test.debug",
         "onCommand:java.test.cancel",
@@ -88,16 +86,6 @@
                     "group": "testExplorer@1"
                 },
                 {
-                    "command": "java.test.explorer.run.config",
-                    "when": "view == testExplorer",
-                    "group": "testExplorer@2"
-                },
-                {
-                    "command": "java.test.explorer.debug.config",
-                    "when": "view == testExplorer",
-                    "group": "testExplorer@3"
-                },
-                {
                     "command": "java.test.explorer.refresh",
                     "when": "view == testExplorer",
                     "group": "testExplorer@4"
@@ -110,14 +98,6 @@
                 },
                 {
                     "command": "java.test.explorer.debug",
-                    "when": "never"
-                },
-                {
-                    "command": "java.test.explorer.run.config",
-                    "when": "never"
-                },
-                {
-                    "command": "java.test.explorer.debug.config",
                     "when": "never"
                 },
                 {
@@ -153,16 +133,6 @@
                     "light": "resources/media/light/debug.svg",
                     "dark": "resources/media/dark/debug.svg"
                 },
-                "category": "Java"
-            },
-            {
-                "command": "java.test.explorer.run.config",
-                "title": "%contributes.commands.java.test.explorer.run.config.title%",
-                "category": "Java"
-            },
-            {
-                "command": "java.test.explorer.debug.config",
-                "title": "%contributes.commands.java.test.explorer.debug.config.title%",
                 "category": "Java"
             },
             {
@@ -216,6 +186,17 @@
                     "description": "%configuration.java.test.message.hintForDeprecatedConfig.description%",
                     "scope": "application"
                 },
+                "java.test.message.hintForSetingDefaultConfig": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%configuration.java.test.message.hintForSetingDefaultConfig.description%",
+                    "scope": "application"
+                },
+                "java.test.defaultConfig": {
+                    "type": "string",
+                    "description": "%configuration.java.test.defaultConfig.description%",
+                    "scope": "resource"
+                },
                 "java.test.config": {
                     "type": "array",
                     "description": "%configuration.java.test.config.description%",
@@ -226,6 +207,7 @@
                             "name": {
                                 "type": "string",
                                 "description": "%configuration.java.test.config.name.description%",
+                                "pattern": "^((?!__EMPTY_CONFIG__).)*$",
                                 "default": ""
                             },
                             "workingDirectory": {

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
                             "name": {
                                 "type": "string",
                                 "description": "%configuration.java.test.config.name.description%",
-                                "pattern": "^((?!__EMPTY_CONFIG__).)*$",
+                                "pattern": "^((?!__BUILTIN_CONFIG__).)*$",
                                 "default": ""
                             },
                             "workingDirectory": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,6 +12,8 @@
     "configuration.java.test.report.position.description": "Specify where to show the test report",
     "configuration.java.test.log.level.description": "Specify the level of the test logs",
     "configuration.java.test.message.hintForDeprecatedConfig.description": "Specify whether the extension will show hint dialog when deprecated configuration file is used",
+    "configuration.java.test.message.hintForSetingDefaultConfig.description": "Specify whether the extension will show hint to set default test configuration",
+    "configuration.java.test.defaultConfig.description": "Specify the name of the default test configuration",
     "configuration.java.test.config.description": "Specify the configurations for running the tests",
     "configuration.java.test.config.item.description": "Specify the configuration item for running the tests",
     "configuration.java.test.config.name.description": "Specify the name of the configuration item",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -12,6 +12,8 @@
     "configuration.java.test.report.position.description": "设定测试报告的显示位置",
     "configuration.java.test.log.level.description": "设定日志级别",
     "configuration.java.test.message.hintForDeprecatedConfig.description": "设定插件是否会对使用弃用的配置文件进行提示",
+    "configuration.java.test.message.hintForSetingDefaultConfig.description": "设定插件是否会对设置默认测试配置项进行提示",
+    "configuration.java.test.defaultConfig.description": "设定默认测试配置项的名称",
     "configuration.java.test.config.description": "设定运行测试的配置信息",
     "configuration.java.test.config.item.description": "设定运行测试时所用的配置项",
     "configuration.java.test.config.name.description": "命名配置项",

--- a/src/commands/executeTests.ts
+++ b/src/commands/executeTests.ts
@@ -10,7 +10,7 @@ export async function runTests(tests: ITestItem[]): Promise<void> {
     return window.withProgress(
         { location: ProgressLocation.Notification, cancellable: true },
         (progress: Progress<any>, token: CancellationToken): Promise<void> => {
-            return executeTests(tests, false /* isDebug */, true /* usingDefaultConfig */, progress, token);
+            return executeTests(tests, false /* isDebug */, progress, token);
         },
     );
 }
@@ -19,15 +19,15 @@ export async function debugTests(tests: ITestItem[]): Promise<void> {
     return window.withProgress(
         { location: ProgressLocation.Notification, cancellable: true },
         (progress: Progress<any>, token: CancellationToken): Promise<void> => {
-            return executeTests(tests, true /* isDebug */, true /* usingDefaultConfig */, progress, token);
+            return executeTests(tests, true /* isDebug */, progress, token);
         },
     );
 }
 
-export async function executeTests(tests: ITestItem[], isDebug: boolean, usingDefaultConfig: boolean, progress: Progress<any>, token: CancellationToken): Promise<void> {
+export async function executeTests(tests: ITestItem[], isDebug: boolean, progress: Progress<any>, token: CancellationToken): Promise<void> {
     token.onCancellationRequested(() => {
         commands.executeCommand(JavaTestRunnerCommands.JAVA_TEST_CANCEL);
     });
     progress.report({ message: 'Running tests...'});
-    return runnerExecutor.run(tests, isDebug, usingDefaultConfig);
+    return runnerExecutor.run(tests, isDebug);
 }

--- a/src/commands/explorerCommands.ts
+++ b/src/commands/explorerCommands.ts
@@ -14,22 +14,14 @@ export async function openTextDocumentForNode(node: TestTreeNode): Promise<void>
 }
 
 export async function runTestsFromExplorer(node?: TestTreeNode): Promise<void> {
-    return executeTestsFromExplorer(false /* isDebug */, true /* usingDefaultConfig */, node);
+    return executeTestsFromExplorer(false /* isDebug */, node);
 }
 
 export async function debugTestsFromExplorer(node?: TestTreeNode): Promise<void> {
-    return executeTestsFromExplorer(true /* isDebug */, true /* usingDefaultConfig */, node);
+    return executeTestsFromExplorer(true /* isDebug */, node);
 }
 
-export async function runTestsWithConfigFromExplorer(node?: TestTreeNode): Promise<void> {
-    return executeTestsFromExplorer(false /* isDebug */, false /* usingDefaultConfig */, node);
-}
-
-export async function debugTestsWithFromExplorer(node?: TestTreeNode): Promise<void> {
-    return executeTestsFromExplorer(true /* isDebug */, false /* usingDefaultConfig */, node);
-}
-
-async function executeTestsFromExplorer(isDebug: boolean, usingDefaultConfig: boolean, node?: TestTreeNode): Promise<void> {
+async function executeTestsFromExplorer(isDebug: boolean, node?: TestTreeNode): Promise<void> {
     return window.withProgress(
         { location: ProgressLocation.Notification, cancellable: true },
         async (progress: Progress<any>, token: CancellationToken): Promise<void> => {
@@ -39,7 +31,7 @@ async function executeTestsFromExplorer(isDebug: boolean, usingDefaultConfig: bo
             if (token.isCancellationRequested) {
                 return;
             }
-            return executeTests(tests, isDebug, usingDefaultConfig, progress, token);
+            return executeTests(tests, isDebug, progress, token);
         },
     );
 }

--- a/src/constants/configs.ts
+++ b/src/constants/configs.ts
@@ -10,8 +10,13 @@ export const LOG_FILE_MAX_NUMBER: number = 2;
 export const LOG_LEVEL_SETTING_KEY: string = 'java.test.log.level';
 export const DEFAULT_LOG_LEVEL: string = 'info';
 
+export const DEFAULT_CONFIG_NAME_SETTING_KEY: string = 'java.test.defaultConfig';
+export const CONFIG_SETTING_KEY: string = 'java.test.config';
+export const EMPTY_CONFIG_NAME: string = '__EMPTY_CONFIG__';
+
 export const REPORT_POSITION_SETTING_KEY: string = 'java.test.report.position';
 export const DEFAULT_REPORT_POSITION: string = 'sideView';
 
 export const HINT_FOR_DEPRECATED_CONFIG_SETTING_KEY: string = 'java.test.message.hintForDeprecatedConfig';
 export const CONFIG_DOCUMENT_URL: string = 'https://aka.ms/java-test-config';
+export const HINT_FOR_DEFAULT_CONFIG_SETTING_KEY: string = 'java.test.message.hintForSetingDefaultConfig';

--- a/src/constants/configs.ts
+++ b/src/constants/configs.ts
@@ -12,7 +12,7 @@ export const DEFAULT_LOG_LEVEL: string = 'info';
 
 export const DEFAULT_CONFIG_NAME_SETTING_KEY: string = 'java.test.defaultConfig';
 export const CONFIG_SETTING_KEY: string = 'java.test.config';
-export const EMPTY_CONFIG_NAME: string = '__EMPTY_CONFIG__';
+export const BUILTIN_CONFIG_NAME: string = '__BUILTIN_CONFIG__';
 
 export const REPORT_POSITION_SETTING_KEY: string = 'java.test.report.position';
 export const DEFAULT_REPORT_POSITION: string = 'sideView';

--- a/src/constants/dialogOptions.ts
+++ b/src/constants/dialogOptions.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+export const LEARN_MORE: string = 'Learn More';
+export const NEVER_SHOW: string = 'Never Show again';
+export const YES: string = 'Yes';
+export const NO: string = 'No';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { commands, Disposable, Extension, ExtensionContext, extensions, language
 import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentOperation } from 'vscode-extension-telemetry-wrapper';
 import { testCodeLensProvider } from './codeLensProvider';
 import { debugTests, runTests } from './commands/executeTests';
-import { debugTestsFromExplorer, debugTestsWithFromExplorer, openTextDocumentForNode, runTestsFromExplorer, runTestsWithConfigFromExplorer } from './commands/explorerCommands';
+import { debugTestsFromExplorer, openTextDocumentForNode, runTestsFromExplorer } from './commands/explorerCommands';
 import { openLogFile, showOutputChannel } from './commands/logCommands';
 import { JavaTestRunnerCommands } from './constants/commands';
 import { explorerNodeManager } from './explorer/explorerNodeManager';
@@ -61,8 +61,6 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
         instrumentAndRegisterCommand(JavaTestRunnerCommands.DEBUG_TEST_FROM_CODELENS, async (tests: ITestItem[]) => await debugTests(tests)),
         instrumentAndRegisterCommand(JavaTestRunnerCommands.RUN_TEST_FROM_EXPLORER, async (node?: TestTreeNode) => await runTestsFromExplorer(node)),
         instrumentAndRegisterCommand(JavaTestRunnerCommands.DEBUG_TEST_FROM_EXPLORER, async (node?: TestTreeNode) => await debugTestsFromExplorer(node)),
-        instrumentAndRegisterCommand(JavaTestRunnerCommands.RUN_TEST_WITH_CONFIG_FROM_EXPLORER, async (node?: TestTreeNode) => await runTestsWithConfigFromExplorer(node)),
-        instrumentAndRegisterCommand(JavaTestRunnerCommands.DEBUG_TEST_WITH_CONFIG_FROM_EXPLORER, async (node?: TestTreeNode) => await debugTestsWithFromExplorer(node)),
         instrumentAndRegisterCommand(JavaTestRunnerCommands.SHOW_TEST_REPORT, async (tests: ITestItem[]) => await testReportProvider.report(tests)),
         instrumentAndRegisterCommand(JavaTestRunnerCommands.SHOW_TEST_OUTPUT, () => showOutputChannel()),
         instrumentAndRegisterCommand(JavaTestRunnerCommands.OPEN_TEST_LOG, async () => await openLogFile(storagePath)),

--- a/src/runConfigs.ts
+++ b/src/runConfigs.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT license.
 
 export interface IExecutionConfig {
-    name: string;
-    projectName: string;
-    workingDirectory: string;
-    args: any[];
-    vmargs: any[];
-    env: { [key: string]: string; };
-    preLaunchTask: string;
+    name?: string;
+    projectName?: string;
+    workingDirectory?: string;
+    args?: any[];
+    vmargs?: any[];
+    env?: { [key: string]: string; };
+    preLaunchTask?: string;
 }
 
 export interface IExecutionConfigGroup {
@@ -20,3 +20,8 @@ export interface ITestConfig {
     run: IExecutionConfigGroup;
     debug: IExecutionConfigGroup;
 }
+
+export const __EMPTY_CONFIG__: IExecutionConfig = {
+    name: '__EMPTY_CONFIG__',
+    workingDirectory: '${workspaceFolder}',
+};

--- a/src/runConfigs.ts
+++ b/src/runConfigs.ts
@@ -21,7 +21,7 @@ export interface ITestConfig {
     debug: IExecutionConfigGroup;
 }
 
-export const __EMPTY_CONFIG__: IExecutionConfig = {
-    name: '__EMPTY_CONFIG__',
+export const __BUILTIN_CONFIG__: IExecutionConfig = {
+    name: '__BUILTIN_CONFIG__',
     workingDirectory: '${workspaceFolder}',
 };

--- a/src/runners/runnerExecutor.ts
+++ b/src/runners/runnerExecutor.ts
@@ -27,7 +27,7 @@ class RunnerExecutor {
         this._context = context;
     }
 
-    public async run(testItems: ITestItem[], isDebug: boolean, usingDefaultConfig: boolean): Promise<void> {
+    public async run(testItems: ITestItem[], isDebug: boolean): Promise<void> {
         if (this._isRunning) {
             window.showInformationMessage('A test session is currently running. Please wait until it finishes.');
             return;
@@ -44,7 +44,7 @@ class RunnerExecutor {
             this._runnerMap = this.classifyTestsByKind(testItems);
             const finalResults: ITestResult[] = [];
             for (const [runner, tests] of this._runnerMap.entries()) {
-                const config: IExecutionConfig | undefined = await testConfigManager.loadRunConfig(tests, isDebug, usingDefaultConfig);
+                const config: IExecutionConfig | undefined = await testConfigManager.loadRunConfig(tests, isDebug);
                 await runner.setup(tests, isDebug, config);
                 await runner.execPreLaunchTaskIfExist();
                 const results: ITestResult[] = await runner.run();
@@ -84,12 +84,12 @@ class RunnerExecutor {
     }
 
     private classifyTestsByKind(tests: ITestItem[]): Map<ITestRunner, ITestItem[]> {
-        const testMap: Map<Uri, ITestItem[]> = this.mapTestsByProjectAndKind(tests);
+        const testMap: Map<string, ITestItem[]> = this.mapTestsByProjectAndKind(tests);
         return this.mapTestsByRunner(testMap);
     }
 
-    private mapTestsByProjectAndKind(tests: ITestItem[]): Map<Uri, ITestItem[]> {
-        const map: Map<Uri, ITestItem[]> = new Map<Uri, ITestItem[]>();
+    private mapTestsByProjectAndKind(tests: ITestItem[]): Map<string, ITestItem[]> {
+        const map: Map<string, ITestItem[]> = new Map<string, ITestItem[]>();
         for (const test of tests) {
             if (!(test.kind in TestKind)) {
                 logger.error(`Unkonwn kind of test item: ${test.fullName}`);
@@ -100,17 +100,18 @@ class RunnerExecutor {
                 logger.error(`The test: ${test.fullName} does not belong to any workspace folder`);
                 continue;
             }
-            const testArray: ITestItem[] | undefined = map.get(workspaceFolder.uri);
+            const key: string = workspaceFolder.uri.toString() + test.kind.toString();
+            const testArray: ITestItem[] | undefined = map.get(key);
             if (testArray) {
                 testArray.push(test);
             } else {
-                map.set(workspaceFolder.uri, [test]);
+                map.set(key, [test]);
             }
         }
         return map;
     }
 
-    private mapTestsByRunner(testsPerProjectAndKind: Map<Uri, ITestItem[]>): Map<ITestRunner, ITestItem[]> {
+    private mapTestsByRunner(testsPerProjectAndKind: Map<string, ITestItem[]>): Map<ITestRunner, ITestItem[]> {
         const map: Map<ITestRunner, ITestItem[]> = new Map<ITestRunner, ITestItem[]>();
         for (const tests of testsPerProjectAndKind.values()) {
             const runner: ITestRunner | undefined = this.getRunnerByKind(tests[0].kind);

--- a/src/runners/runnerExecutor.ts
+++ b/src/runners/runnerExecutor.ts
@@ -100,7 +100,7 @@ class RunnerExecutor {
                 logger.error(`The test: ${test.fullName} does not belong to any workspace folder`);
                 continue;
             }
-            const key: string = workspaceFolder.uri.toString() + test.kind.toString();
+            const key: string = `${workspaceFolder.uri}/${test.kind}`;
             const testArray: ITestItem[] | undefined = map.get(key);
             if (testArray) {
                 testArray.push(test);

--- a/src/testConfigManager.ts
+++ b/src/testConfigManager.ts
@@ -40,10 +40,10 @@ class TestConfigManager {
                     return config.name === defaultConfigName;
                 });
                 if (defaultConfigs.length === 0) {
-                    window.showWarningMessage(`Failed to find the default configuration item: ${defaultConfigName}, tests will be launched without configurations.`);
+                    window.showWarningMessage(`Failed to find the default configuration item: ${defaultConfigName}, tests will be launched with built-in configurations.`);
                     return __BUILTIN_CONFIG__;
                 } else if (defaultConfigs.length > 1) {
-                    window.showWarningMessage(`More than one configuration item found with name: ${defaultConfigName}, tests will be launched without configurations.`);
+                    window.showWarningMessage(`More than one configuration item found with name: ${defaultConfigName}, tests will be launched with built-in configurations.`);
                     return __BUILTIN_CONFIG__;
                 } else {
                     return defaultConfigs[0];
@@ -117,10 +117,10 @@ class TestConfigManager {
         if (choices.length === 1) {
             return choices[0].item;
         }
-        const selection: IRunConfigQuickPick | undefined = await window.showQuickPick(choices, { placeHolder: 'Select test config' });
+        const selection: IRunConfigQuickPick | undefined = await window.showQuickPick(choices, { placeHolder: 'Select test configuration' });
         if (!selection) {
-            window.showWarningMessage('No configuration item is picked, tests will be launched without configurations.');
-            return undefined;
+            window.showWarningMessage('No configuration item is picked, tests will be launched with built-in configurations.');
+            return __BUILTIN_CONFIG__;
         }
         if (workspaceFolderUri) {
             this.askPreferenceForConfig(configs, selection.item, workspaceFolderUri);
@@ -150,6 +150,10 @@ class TestConfigManager {
 
     private async askPreferenceForConfig(configs: IExecutionConfig[], selectedConfig: IExecutionConfig, workspaceFolderUri: Uri): Promise<void> {
         const workspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration(undefined, workspaceFolderUri);
+        const showHint: boolean | undefined = workspaceConfiguration.get<boolean>(HINT_FOR_DEFAULT_CONFIG_SETTING_KEY);
+        if (!showHint) {
+            return;
+        }
         const choice: string | undefined = await window.showInformationMessage('Would you like to set this configuration as default?', YES, NO, NEVER_SHOW);
         if (!choice || choice === NO) {
             return;

--- a/src/testConfigManager.ts
+++ b/src/testConfigManager.ts
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as crypto from 'crypto';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { commands, QuickPickItem, Uri, window, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+import { commands, ConfigurationTarget, QuickPickItem, Uri, window, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
 import { sendInfo } from 'vscode-extension-telemetry-wrapper';
-import { CONFIG_DOCUMENT_URL, HINT_FOR_DEPRECATED_CONFIG_SETTING_KEY } from './constants/configs';
+import { CONFIG_DOCUMENT_URL, CONFIG_SETTING_KEY, DEFAULT_CONFIG_NAME_SETTING_KEY, EMPTY_CONFIG_NAME, HINT_FOR_DEFAULT_CONFIG_SETTING_KEY,
+    HINT_FOR_DEPRECATED_CONFIG_SETTING_KEY } from './constants/configs';
+import { LEARN_MORE, NEVER_SHOW, NO, YES } from './constants/dialogOptions';
 import { ITestItem } from './protocols';
-import { IExecutionConfig, IExecutionConfigGroup, ITestConfig } from './runConfigs';
+import { __EMPTY_CONFIG__, IExecutionConfig, IExecutionConfigGroup, ITestConfig } from './runConfigs';
 
 class TestConfigManager {
     private readonly configRelativePath: string;
@@ -19,19 +22,34 @@ class TestConfigManager {
     }
 
     // The test items that belong to a test runner, here the test items should be in the same workspace folder.
-    public async loadRunConfig(tests: ITestItem[], isDebug: boolean, usingDefaultConfig: boolean): Promise<IExecutionConfig | undefined> {
+    public async loadRunConfig(tests: ITestItem[], isDebug: boolean): Promise<IExecutionConfig | undefined> {
         const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(Uri.parse(tests[0].uri));
         if (!workspaceFolder) {
             return undefined;
         }
 
-        const configs: IExecutionConfig[] | undefined = workspace.getConfiguration('java.test', workspaceFolder.uri).get<IExecutionConfig[]>('config');
+        const configs: IExecutionConfig[] | undefined = workspace.getConfiguration(undefined, workspaceFolder.uri).get<IExecutionConfig[]>(CONFIG_SETTING_KEY);
         if (configs && configs.length > 0) {
             // Use the new config schema
-            if (usingDefaultConfig) {
-                return configs[0];
+            const defaultConfigName: string | undefined = workspace.getConfiguration(undefined, workspaceFolder.uri).get<string>(DEFAULT_CONFIG_NAME_SETTING_KEY);
+            if (defaultConfigName) {
+                if (defaultConfigName === EMPTY_CONFIG_NAME) {
+                    return __EMPTY_CONFIG__;
+                }
+                const defaultConfigs: IExecutionConfig[] = configs.filter((config: IExecutionConfig) => {
+                    return config.name === defaultConfigName;
+                });
+                if (defaultConfigs.length === 0) {
+                    window.showWarningMessage(`Failed to find the default configuration item: ${defaultConfigName}, tests will be launched without configurations.`);
+                    return undefined;
+                } else if (defaultConfigs.length > 1) {
+                    window.showWarningMessage(`More than one configuration item found with name: ${defaultConfigName}, tests will be launched without configurations.`);
+                    return undefined;
+                } else {
+                    return defaultConfigs[0];
+                }
             }
-            return await this.selectQuickPick(configs);
+            return await this.selectQuickPick(configs, workspaceFolder.uri);
         } else {
             // Using deprecated config shcema
             const deprecatedConfigs: IExecutionConfigGroup[] = [];
@@ -43,18 +61,15 @@ class TestConfigManager {
             const content: string = await fse.readFile(configFullPath, 'utf-8');
             const deprecatedConfig: ITestConfig = JSON.parse(content);
             deprecatedConfigs.push(isDebug ? deprecatedConfig.debug : deprecatedConfig.run);
-            return await this.selectDeprecatedConfig(deprecatedConfigs, usingDefaultConfig);
+            return await this.selectDeprecatedConfig(deprecatedConfigs);
         }
     }
 
-    private async selectDeprecatedConfig(configs: IExecutionConfigGroup[], usingDefaultConfig: boolean): Promise<IExecutionConfig | undefined> {
+    private async selectDeprecatedConfig(configs: IExecutionConfigGroup[]): Promise<IExecutionConfig | undefined> {
         if (configs.length === 0) {
             return undefined;
         }
-        if (usingDefaultConfig) {
-            if (configs.length !== 1 || !configs[0].default) {
-                return undefined;
-            }
+        if (configs[0].default) {
             const runConfig: IExecutionConfigGroup = configs[0];
             const candidates: IExecutionConfig[] = runConfig.items.filter((item: IExecutionConfig) => item.name === runConfig.default);
             if (candidates.length === 0) {
@@ -63,12 +78,14 @@ class TestConfigManager {
             }
             if (candidates.length > 1) {
                 window.showWarningMessage(`Duplicate configs with default name: ${runConfig.default}.`);
+                return undefined;
             }
             return candidates[0];
         }
 
         if (configs.length > 1) {
             window.showWarningMessage('It is not supported to run tests with config from multi root.');
+            return undefined;
         }
 
         const configItems: IExecutionConfig[] = [];
@@ -78,12 +95,18 @@ class TestConfigManager {
         return this.selectQuickPick(configItems);
     }
 
-    private async selectQuickPick(configs: IExecutionConfig[]): Promise<IExecutionConfig> {
+    private async selectQuickPick(configs: IExecutionConfig[], workspaceFolderUri?: Uri): Promise<IExecutionConfig | undefined> {
         interface IRunConfigQuickPick extends QuickPickItem {
             item: IExecutionConfig;
         }
 
         const choices: IRunConfigQuickPick[] = [];
+        choices.push({
+            label: 'Empty Configuration',
+            description: 'Built-in configuration',
+            detail: JSON.stringify(__EMPTY_CONFIG__),
+            item: __EMPTY_CONFIG__,
+        });
         for (let i: number = 0; i < configs.length; i++) {
             const label: string = configs[i].name ? configs[i].name! : `Configuration #${i + 1}`;
             choices.push({
@@ -94,8 +117,13 @@ class TestConfigManager {
         }
         const selection: IRunConfigQuickPick | undefined = await window.showQuickPick(choices, { placeHolder: 'Select test config' });
         if (!selection) {
-            throw new Error('Please specify the test config to use.');
+            window.showWarningMessage('No configuration item is picked, tests will be launched without configurations.');
+            return undefined;
         }
+        if (workspaceFolderUri) {
+            this.askPreferenceForConfig(configs, selection.item, workspaceFolderUri);
+        }
+
         return selection.item;
     }
 
@@ -106,8 +134,6 @@ class TestConfigManager {
         if (!showHint) {
             return;
         }
-        const LEARN_MORE: string = 'Learn More';
-        const NEVER_SHOW: string = 'Never Show again';
         const choice: string | undefined = await window.showInformationMessage(
             'Using launch.test.json to run tests is deprecated, please use the "java.test.config" setting instead',
             NEVER_SHOW,
@@ -117,6 +143,25 @@ class TestConfigManager {
             workspaceConfiguration.update(HINT_FOR_DEPRECATED_CONFIG_SETTING_KEY, false, true /* global setting */);
         } else if (choice === LEARN_MORE) {
             commands.executeCommand('vscode.open', Uri.parse(CONFIG_DOCUMENT_URL));
+        }
+    }
+
+    private async askPreferenceForConfig(configs: IExecutionConfig[], selectedConfig: IExecutionConfig, workspaceFolderUri: Uri): Promise<void> {
+        const workspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration(undefined, workspaceFolderUri);
+        const choice: string | undefined = await window.showInformationMessage('Would you like to set this configuration as default?', YES, NO, NEVER_SHOW);
+        if (!choice || choice === NO) {
+            return;
+        } else if (choice === NEVER_SHOW) {
+            workspaceConfiguration.update(HINT_FOR_DEFAULT_CONFIG_SETTING_KEY, false, true /* global setting */);
+            return;
+        }
+        if (selectedConfig.name) {
+            workspaceConfiguration.update(DEFAULT_CONFIG_NAME_SETTING_KEY, selectedConfig.name, ConfigurationTarget.WorkspaceFolder);
+        } else {
+            const randomName: string = `config-${crypto.randomBytes(3).toString('hex')}`;
+            selectedConfig.name = randomName;
+            workspaceConfiguration.update(DEFAULT_CONFIG_NAME_SETTING_KEY, selectedConfig.name, ConfigurationTarget.WorkspaceFolder);
+            workspaceConfiguration.update(CONFIG_SETTING_KEY, configs, ConfigurationTarget.WorkspaceFolder);
         }
     }
 }

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -4,7 +4,7 @@
 import { Uri, workspace, WorkspaceFolder } from 'vscode';
 import { logger } from '../logger/logger';
 
-export function resolveWorkingDirectory(testUriString: string, cwdConfig: string): string | undefined {
+export function resolveWorkingDirectory(testUriString: string, cwdConfig: string | undefined): string | undefined {
     if (cwdConfig && /\$\{workspacefolder\}/i.test(cwdConfig.trim())) {
         const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(Uri.parse(testUriString));
         if (workspaceFolder) {

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -4,8 +4,8 @@
 import { Uri, workspace, WorkspaceFolder } from 'vscode';
 import { logger } from '../logger/logger';
 
-export function resolveWorkingDirectory(testUriString: string, cwdConfig: string | undefined): string | undefined {
-    if (cwdConfig && /\$\{workspacefolder\}/i.test(cwdConfig.trim())) {
+export function resolveWorkingDirectory(testUriString: string, cwd: string | undefined): string | undefined {
+    if (cwd && /\$\{workspacefolder\}/i.test(cwd.trim())) {
         const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(Uri.parse(testUriString));
         if (workspaceFolder) {
             return workspaceFolder.uri.fsPath;
@@ -13,5 +13,5 @@ export function resolveWorkingDirectory(testUriString: string, cwdConfig: string
         logger.error(`Failed to parse the working directory for test: ${testUriString}`);
         return undefined;
     }
-    return cwdConfig;
+    return cwd;
 }


### PR DESCRIPTION
related to #524 

1. Remove the command: run/debug with configuration
2. Add a built-in configuration: {: "${workspaceFolder}"}
3. Set default configuration into a setting