### PR TITLE
Get the project name from the test item itself instead of reading the config file

### DIFF
--- a/src/runners/baseRunner/BaseRunner.ts
+++ b/src/runners/baseRunner/BaseRunner.ts
@@ -104,7 +104,8 @@ export abstract class BaseRunner implements ITestRunner {
                         request: 'attach',
                         hostName: 'localhost',
                         port: this.port,
-                        projectName: this.config ? this.config.projectName : undefined,
+                        // Tests in each runner has been classified according to the project they belong to
+                        projectName: this.tests[0].project,
                     });
                 }, 500);
             }

--- a/src/runners/runnerExecutor.ts
+++ b/src/runners/runnerExecutor.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { ExtensionContext, Uri, window, workspace, WorkspaceFolder } from 'vscode';
+import { ExtensionContext, window } from 'vscode';
 import { testCodeLensProvider } from '../codeLensProvider';
 import { logger } from '../logger/logger';
 import { ITestItem, TestKind } from '../protocols';

--- a/src/runners/runnerExecutor.ts
+++ b/src/runners/runnerExecutor.ts
@@ -95,12 +95,7 @@ class RunnerExecutor {
                 logger.error(`Unkonwn kind of test item: ${test.fullName}`);
                 continue;
             }
-            const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(Uri.parse(test.uri));
-            if (!workspaceFolder) {
-                logger.error(`The test: ${test.fullName} does not belong to any workspace folder`);
-                continue;
-            }
-            const key: string = `${workspaceFolder.uri}/${test.kind}`;
+            const key: string = `${test.project}/${test.kind}`;
             const testArray: ITestItem[] | undefined = map.get(key);
             if (testArray) {
                 testArray.push(test);


### PR DESCRIPTION
Fix #573 