### PR TITLE
Upgrade JUnit5 to 1.3.2

### DIFF
--- a/java-extension/com.microsoft.java.test.runner/pom.xml
+++ b/java-extension/com.microsoft.java.test.runner/pom.xml
@@ -25,12 +25,12 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>1.1.0</version>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-console-standalone</artifactId>
-      <version>1.1.0</version>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/java-extension/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/junit5/CustomizedConsoleLauncher.java
+++ b/java-extension/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/junit5/CustomizedConsoleLauncher.java
@@ -17,14 +17,14 @@ import com.microsoft.java.test.runner.common.TestOutputStream;
 
 import org.junit.platform.console.options.CommandLineOptions;
 import org.junit.platform.console.options.CommandLineOptionsParser;
-import org.junit.platform.console.options.JOptSimpleCommandLineOptionsParser;
+import org.junit.platform.console.options.PicocliCommandLineOptionsParser;;
 
 public class CustomizedConsoleLauncher implements ITestLauncher {
 
     @Override
     public void execute(String[] args) {
         try {
-            final CommandLineOptionsParser parser = new JOptSimpleCommandLineOptionsParser();
+            final CommandLineOptionsParser parser = new PicocliCommandLineOptionsParser();
             final CommandLineOptions options = parser.parse(args);
             new CustomizedConsoleTestExecutor(options).executeTests();
         } catch (final Exception ex) {

--- a/java-extension/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/junit5/CustomizedConsoleLauncher.java
+++ b/java-extension/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/junit5/CustomizedConsoleLauncher.java
@@ -17,7 +17,7 @@ import com.microsoft.java.test.runner.common.TestOutputStream;
 
 import org.junit.platform.console.options.CommandLineOptions;
 import org.junit.platform.console.options.CommandLineOptionsParser;
-import org.junit.platform.console.options.PicocliCommandLineOptionsParser;;
+import org.junit.platform.console.options.PicocliCommandLineOptionsParser;
 
 public class CustomizedConsoleLauncher implements ITestLauncher {
 


### PR DESCRIPTION
The `JOptSimpleCommandLineOptionsParser` is replaced by `PicocliCommandLineOptionsParser` in JUnit 5.

Using `JOptSimpleCommandLineOptionsParser` may not able to parse the argument correctly, thus causing some the test cases are skipped.