### PR TITLE
Several small fixes

### DIFF
--- a/resources/templates/report_method_table.pug
+++ b/resources/templates/report_method_table.pug
@@ -23,7 +23,7 @@ mixin collapseMethodTable(children, type)
                                 span.badge.badge-secondary Skipped
                         div.col-2.text-right #{method.result && method.result.duration ? method.result.duration + "ms" : "N/A"}
                         div.col-1.text-right
-                            a(href="#", title="Navigate to the method", uri=`${method.uri}`, range=`${method.range}`)
+                            a(href="#", title="Navigate to Source", uri=`${method.uri}`, range=`${method.range}`)
                                 i.fa.fa-external-link
                     div.mt-2.pl-2.accordion-body(id=`${type}-${classIdx}-${methodIdx}`, class="collapse")
                         div.row

--- a/src/runners/runnerExecutor.ts
+++ b/src/runners/runnerExecutor.ts
@@ -75,6 +75,7 @@ class RunnerExecutor {
 
     public async cleanUp(isCancel: boolean): Promise<void> {
         try {
+            this._isRunning = false;
             const promises: Array<Promise<void>> = [];
             if (this._runnerMap) {
                 for (const runner of this._runnerMap.keys()) {
@@ -91,7 +92,6 @@ class RunnerExecutor {
         } catch (error) {
             logger.error('Failed to clean up', error);
         }
-        this._isRunning = false;
     }
 
     private classifyTestsByKind(tests: ITestItem[]): Map<ITestRunner, ITestItem[]> {

--- a/src/testConfigManager.ts
+++ b/src/testConfigManager.ts
@@ -37,7 +37,7 @@ class TestConfigManager {
             if (_.isPlainObject(configSetting)) {
                 configItems.push(configSetting as IExecutionConfig);
             } else if (_.isArray(configSetting)) {
-                configItems.push(...configSetting);
+                configItems.push(...configSetting as IExecutionConfig[]);
             }
 
             const defaultConfigName: string | undefined = workspace.getConfiguration(undefined, workspaceFolder.uri).get<string>(DEFAULT_CONFIG_NAME_SETTING_KEY);


### PR DESCRIPTION
Several code changes including:
- Better tooltip content for navigating button in the test report
- Set the executor status at first in cleanup method
- Explicitly cast the `configSetting` to array when we know that it is.