### PR TITLE
[bugfix] Put the target/test-class before target/class when calculating the classpath

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/ProjectUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/ProjectUtils.java
@@ -119,6 +119,18 @@ public final class ProjectUtils {
                 .collect(Collectors.toList());
     }
 
+    public static Set<IPath> getTestOutputPath(IJavaProject project) throws JavaModelException {
+        final IClasspathEntry[] entries = project.getRawClasspath();
+        final IPath projectLocation = project.getProject().getLocation();
+        return Arrays.stream(entries)
+                .filter(entry -> isTest(entry))
+                .map(entry -> {
+                    final IPath relativePath = entry.getOutputLocation().makeRelativeTo(project.getPath());
+                    return projectLocation.append(relativePath);
+                })
+                .collect(Collectors.toSet());
+    }
+
     private static boolean isTest(IClasspathEntry entry) {
         if (entry.getEntryKind() != ClasspathEntry.CPE_SOURCE) {
             return false;

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/RuntimeClassPathUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/RuntimeClassPathUtils.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.launching.JavaRuntime;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -56,10 +57,24 @@ public class RuntimeClassPathUtils {
             }
         }
 
-        final List<String> classPathList = new ArrayList<>();
+        final Set<String> classPathSet = new HashSet<>();
         for (final IJavaProject project : projectsToTest) {
-            classPathList.addAll(Arrays.asList(JavaRuntime.computeDefaultRuntimeClassPath(project)));
+            final String[] classPathArray = JavaRuntime.computeDefaultRuntimeClassPath(project);
+            final Set<IPath> testEntriePaths = ProjectUtils.getTestOutputPath(project);
+            Arrays.sort(classPathArray, Comparator.comparing((String pathStr) -> {
+                final Path path = new Path(pathStr);
+                if (path.toFile().isFile()) {
+                    return 1;
+                }
+                for (final IPath testPath: testEntriePaths) {
+                    if (testPath.isPrefixOf(path)) {
+                        return -1;
+                    }
+                }
+                return 1;
+            }));
+            classPathSet.addAll(Arrays.asList(classPathArray));
         }
-        return classPathList.toArray(new String[classPathList.size()]);
+        return classPathSet.toArray(new String[classPathSet.size()]);
     }
 }


### PR DESCRIPTION
To address #534 & #621 

The root cause is that the `application.properties` in `src` is loaded before that in `test`

The `target/test-class` must come before `target/class`.