### PR TITLE
Fix a regression when calculate the classpath

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/RuntimeClassPathUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/RuntimeClassPathUtils.java
@@ -57,7 +57,7 @@ public class RuntimeClassPathUtils {
             }
         }
 
-        final Set<String> classPathSet = new HashSet<>();
+        final List<String> classPathList = new ArrayList<>();
         for (final IJavaProject project : projectsToTest) {
             final String[] classPathArray = JavaRuntime.computeDefaultRuntimeClassPath(project);
             final Set<IPath> testEntriePaths = ProjectUtils.getTestOutputPath(project);
@@ -73,8 +73,8 @@ public class RuntimeClassPathUtils {
                 }
                 return 1;
             }));
-            classPathSet.addAll(Arrays.asList(classPathArray));
+            classPathList.addAll(Arrays.asList(classPathArray));
         }
-        return classPathSet.toArray(new String[classPathSet.size()]);
+        return classPathList.toArray(new String[classPathList.size()]);
     }
 }

--- a/src/utils/commandUtils.ts
+++ b/src/utils/commandUtils.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as _ from 'lodash';
 import { commands, Uri } from 'vscode';
 import { JavaLanguageServerCommands, JavaTestRunnerDelegateCommands } from '../constants/commands';
 import { IProjectInfo, ISearchTestItemParams, ITestItem } from '../protocols';
@@ -26,8 +27,8 @@ export async function searchTestCodeLens(uri: string): Promise<ITestItem[]> {
 }
 
 export async function resolveRuntimeClassPath(paths: string[]): Promise<string[]> {
-    return await executeJavaLanguageServerCommand<string[]>(
-        JavaTestRunnerDelegateCommands.RESOLVE_RUNTIME_CLASSPATH, paths) || [];
+    return _.uniq(await executeJavaLanguageServerCommand<string[]>(
+        JavaTestRunnerDelegateCommands.RESOLVE_RUNTIME_CLASSPATH, paths) || []);
 }
 
 export async function getProjectInfo(folderUri: Uri): Promise<IProjectInfo[]> {


### PR DESCRIPTION
Fix the regression in #629 

We should use `List` instead of `Set` since `Set` has no order