### PR TITLE
Directly fetch the result from result cache

### DIFF
--- a/src/codeLensProvider.ts
+++ b/src/codeLensProvider.ts
@@ -95,11 +95,12 @@ class TestCodeLensProvider implements CodeLensProvider {
                 if (!resultsInFsPath) {
                     break;
                 }
+                const testMethodMap: Map<string, ITestItem> = new Map<string, ITestItem>();
                 for (const child of test.children) {
-                    details = resultsInFsPath.get(child.fullName);
-                    if (child.level === TestLevel.Method && details) {
-                        testResults.push(Object.assign({}, child, {details}));
-                    }
+                    testMethodMap.set(child.fullName, child);
+                }
+                for (const key of resultsInFsPath.keys()) {
+                    testResults.push(Object.assign({fullName: key, displayName: key}, testMethodMap.get(key), { details: resultsInFsPath.get(key) as ITestResultDetails }));
                 }
             default:
                 break;

--- a/src/runners/baseRunner/BaseRunnerResultAnalyzer.ts
+++ b/src/runners/baseRunner/BaseRunnerResultAnalyzer.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { Uri } from 'vscode';
 import { logger } from '../../logger/logger';
 import { ITestItem, TestLevel } from '../../protocols';
 import { defaultResult, ITestResult, ITestResultDetails } from '../models';
@@ -82,18 +81,6 @@ export abstract class BaseRunnerResultAnalyzer {
 
             resultArray.push(result);
             itemMap.delete(key);
-        }
-        this.addSkippedTests(resultArray, itemMap);
-    }
-
-    protected addSkippedTests(result: ITestResult[], itemMap: Map<string, ITestItem>): void {
-        for (const item of itemMap.values()) {
-            result.push(Object.assign({}, defaultResult, {
-                displayName: item.displayName,
-                fullName: item.fullName,
-                uri: Uri.parse(item.location.uri).toString(),
-                range: item.location.range,
-            }));
         }
     }
 


### PR DESCRIPTION
#### Previous logic:

Get the searching result from the language server, then for each item in the searching result, get the final result from the cache.

#### Now:
Directly show the result in the cache, which aligns with the output of the Test Runner.
