### PR TITLE
feat: Support @TestFactory in JUnit 5

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
@@ -17,7 +17,6 @@ import com.microsoft.java.test.plugin.model.TestLevel;
 import com.microsoft.java.test.plugin.util.TestFrameworkUtils;
 import com.microsoft.java.test.plugin.util.TestItemUtils;
 
-import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
@@ -40,29 +39,6 @@ public abstract class BaseFrameworkSearcher implements TestFrameworkSearcher {
     @Override
     public String[] getTestClassAnnotations() {
         return this.testClassAnnotations;
-    }
-
-    @Override
-    public boolean isTestMethod(IMethod method) {
-        try {
-            final int flags = method.getFlags();
-            if (Flags.isAbstract(flags) || Flags.isStatic(flags)) {
-                return false;
-            }
-            // 'V' is void signature
-            if (method.isConstructor() || !"V".equals(method.getReturnType())) {
-                return false;
-            }
-            for (final String annotation : this.getTestMethodAnnotations()) {
-                if (TestFrameworkUtils.hasAnnotation(method, annotation)) {
-                    return true;
-                }
-            }
-            return false;
-        } catch (final JavaModelException e) {
-            // ignore
-            return false;
-        }
     }
 
     @Override

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
@@ -12,6 +12,7 @@
 package com.microsoft.java.test.plugin.searcher;
 
 import com.microsoft.java.test.plugin.model.TestKind;
+import com.microsoft.java.test.plugin.util.TestFrameworkUtils;
 
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IMethod;
@@ -34,7 +35,19 @@ public class JUnit4TestSearcher extends BaseFrameworkSearcher {
     public boolean isTestMethod(IMethod method) {
         try {
             final int flags = method.getFlags();
-            return Flags.isPublic(flags) && super.isTestMethod(method);
+            if (Flags.isAbstract(flags) || Flags.isStatic(flags) || !Flags.isPublic(flags)) {
+                return false;
+            }
+            // 'V' is void signature
+            if (method.isConstructor() || !"V".equals(method.getReturnType())) {
+                return false;
+            }
+            for (final String annotation : this.testMethodAnnotations) {
+                if (TestFrameworkUtils.hasAnnotation(method, annotation)) {
+                    return true;
+                }
+            }
+            return false;
         } catch (final JavaModelException e) {
             // ignore
             return false;

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
@@ -55,7 +55,6 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
             if (Flags.isAbstract(flags) || Flags.isStatic(flags) || Flags.isPrivate(flags)) {
                 return false;
             }
-            // 'V' is void signature
             if (method.isConstructor()) {
                 return false;
             }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
@@ -12,6 +12,11 @@
 package com.microsoft.java.test.plugin.searcher;
 
 import com.microsoft.java.test.plugin.model.TestKind;
+import com.microsoft.java.test.plugin.util.TestFrameworkUtils;
+
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.JavaModelException;
 
 public class TestNGTestSearcher extends BaseFrameworkSearcher {
 
@@ -24,5 +29,28 @@ public class TestNGTestSearcher extends BaseFrameworkSearcher {
     @Override
     public TestKind getTestKind() {
         return TestKind.TestNG;
+    }
+
+    @Override
+    public boolean isTestMethod(IMethod method) {
+        try {
+            final int flags = method.getFlags();
+            if (Flags.isAbstract(flags) || Flags.isStatic(flags)) {
+                return false;
+            }
+            // 'V' is void signature
+            if (method.isConstructor() || !"V".equals(method.getReturnType())) {
+                return false;
+            }
+            for (final String annotation : this.testMethodAnnotations) {
+                if (TestFrameworkUtils.hasAnnotation(method, annotation)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (final JavaModelException e) {
+            // ignore
+            return false;
+        }
     }
 }

--- a/src/runners/junit5Runner/JUnit5RunnerResultAnalyzer.ts
+++ b/src/runners/junit5Runner/JUnit5RunnerResultAnalyzer.ts
@@ -47,7 +47,7 @@ export class JUnit5RunnerResultAnalyzer extends BaseRunnerResultAnalyzer {
         if (!id) {
             return id;
         }
-        const regex: RegExp = /\[class:(.*?)\]\/\[(?:method|test-template):(.*)\]/gm;
+        const regex: RegExp = /\[class:(.*?)\]\/\[(?:method|test-template|test-factory):(.*)\]/gm;
         const match: RegExpExecArray | null = regex.exec(id);
         if (match && match.length === 3) {
             let methodName: string = match[2];


### PR DESCRIPTION
Resolve #644 

This change overrides the `isTestMethod()` in the child class. It's because different test frameworks have different restrictions about the method signature. And it's hard to differentiate them in just one method. 

![demo](https://user-images.githubusercontent.com/6193897/57744607-76e3fd80-76fc-11e9-82e7-dbc6029f99de.gif)
