### PR TITLE
feat: Automatically add --enable-preview to vmargs when necessary

### DIFF
--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -13,6 +13,8 @@ export namespace JavaTestRunnerDelegateCommands {
     export const SEARCH_TEST_LOCATION: string = 'vscode.java.test.search.location';
     export const RESOLVE_RUNTIME_CLASSPATH: string = 'vscode.java.test.runtime.classpath';
     export const GET_PROJECT_INFO: string = 'vscode.java.test.project.info';
+    // This is a command from the Java Debugger
+    export const JAVA_CHECK_PROJECT_SETTINGS: string = 'vscode.java.checkProjectSettings';
 }
 
 export namespace JavaTestRunnerCommands {

--- a/src/runners/runnerExecutor.ts
+++ b/src/runners/runnerExecutor.ts
@@ -9,6 +9,7 @@ import { IExecutionConfig } from '../runConfigs';
 import { testReportProvider } from '../testReportProvider';
 import { testResultManager } from '../testResultManager';
 import { testStatusBarProvider } from '../testStatusBarProvider';
+import { shouldEnablePreviewFlag } from '../utils/commandUtils';
 import { loadRunConfig } from '../utils/configUtils';
 import { resolve } from '../utils/settingUtils';
 import { ITestRunner } from './ITestRunner';
@@ -45,6 +46,15 @@ class RunnerExecutor {
                 if (!config) {
                     logger.info('Test job is canceled.');
                     continue;
+                }
+
+                // Auto add '--enable-preview' vmArgs if the java project enables COMPILER_PB_ENABLE_PREVIEW_FEATURES flag.
+                if (await shouldEnablePreviewFlag('', tests[0].project)) {
+                    if (config.vmargs) {
+                        config.vmargs.push('--enable-preview');
+                    } else {
+                        config.vmargs = ['--enable-preview'];
+                    }
                 }
 
                 await window.withProgress(

--- a/src/utils/commandUtils.ts
+++ b/src/utils/commandUtils.ts
@@ -38,6 +38,24 @@ export async function resolveRuntimeClassPath(paths: string[]): Promise<string[]
         JavaTestRunnerDelegateCommands.RESOLVE_RUNTIME_CLASSPATH, paths) || []);
 }
 
+export async function checkProjectSettings(className: string, projectName: string, inheritedOptions: boolean, expectedOptions: {[key: string]: string}): Promise<boolean> {
+    return await executeJavaLanguageServerCommand<boolean>(
+        JavaTestRunnerDelegateCommands.JAVA_CHECK_PROJECT_SETTINGS, JSON.stringify({
+            className,
+            projectName,
+            inheritedOptions,
+            expectedOptions,
+        })) || false;
+}
+
+const COMPILER_PB_ENABLE_PREVIEW_FEATURES: string = 'org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures';
+export async function shouldEnablePreviewFlag(className: string, projectName: string): Promise<boolean> {
+    const expectedOptions: { [x: string]: string; } = {
+        [COMPILER_PB_ENABLE_PREVIEW_FEATURES]: 'enabled',
+    };
+    return await checkProjectSettings(className, projectName, true, expectedOptions);
+}
+
 async function executeJavaLanguageServerCommand<T>(...rest: any[]): Promise<T | undefined> {
     try {
         return await commands.executeCommand<T>(JavaLanguageServerCommands.EXECUTE_WORKSPACE_COMMAND, ...rest);


### PR DESCRIPTION
Resolve #669 

This change refers to the [PR](https://github.com/microsoft/vscode-java-debug/pull/561) in VS Code Java Debugger

![demo](https://user-images.githubusercontent.com/6193897/57761935-2044e680-7731-11e9-9dba-535e4487b605.gif)
