### PR TITLE
refactor: Remove the Test Level: NESTED_CLASS

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/TestLevel.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/TestLevel.java
@@ -27,8 +27,5 @@ public enum TestLevel {
     CLASS,
 
     @SerializedName("4")
-    NESTED_CLASS,
-
-    @SerializedName("5")
     METHOD;
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
@@ -81,6 +81,6 @@ public abstract class BaseFrameworkSearcher implements TestFrameworkSearcher {
 
     @Override
     public TestItem parseTestItem(IType type) throws JavaModelException {
-        return TestItemUtils.constructTestItem(type, TestItemUtils.getTestLevelForIType(type), this.getTestKind());
+        return TestItemUtils.constructTestItem(type, TestLevel.CLASS, this.getTestKind());
     }
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
@@ -15,7 +15,6 @@ import com.microsoft.java.test.plugin.model.TestItem;
 import com.microsoft.java.test.plugin.model.TestKind;
 import com.microsoft.java.test.plugin.model.TestLevel;
 
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -55,14 +54,6 @@ public class TestItemUtils {
         return new TestItem(displayName, fullName, uri, projectName, Collections.emptyList(), range, level, kind);
     }
 
-    public static TestLevel getTestLevelForIType(IType type) {
-        if (type.getParent() instanceof ICompilationUnit) {
-            return TestLevel.CLASS;
-        } else {
-            return TestLevel.NESTED_CLASS;
-        }
-    }
-
     public static Range parseTestItemRange(IJavaElement element) throws JavaModelException {
         if (element instanceof ISourceReference) {
             final ISourceRange range = ((ISourceReference) element).getNameRange();
@@ -74,7 +65,6 @@ public class TestItemUtils {
     private static String parseTestItemFullName(IJavaElement element, TestLevel level) {
         switch (level) {
             case CLASS:
-            case NESTED_CLASS:
                 final IType type = (IType) element;
                 return type.getFullyQualifiedName();
             case METHOD:

--- a/src/codeLensProvider.ts
+++ b/src/codeLensProvider.ts
@@ -88,7 +88,6 @@ class TestCodeLensProvider implements CodeLensProvider {
                 }
                 break;
             case TestLevel.Class:
-            case TestLevel.NestedClass:
                 if (!test.children) {
                     break;
                 }
@@ -147,7 +146,7 @@ class TestCodeLensProvider implements CodeLensProvider {
         if (item.level === TestLevel.Method) {
             return 1;
         }
-        if (item.level === TestLevel.Class || item.level === TestLevel.NestedClass) {
+        if (item.level === TestLevel.Class) {
             if (item.children) {
                 return item.children.length;
             }

--- a/src/explorer/testExplorer.ts
+++ b/src/explorer/testExplorer.ts
@@ -84,7 +84,6 @@ export class TestExplorer implements TreeDataProvider<TestTreeNode> {
                     light: this._context.asAbsolutePath(path.join('resources', 'media', 'light', 'method.svg')),
                 };
             case TestLevel.Class:
-            case TestLevel.NestedClass:
                 return {
                     dark: this._context.asAbsolutePath(path.join('resources', 'media', 'dark', 'class.svg')),
                     light: this._context.asAbsolutePath(path.join('resources', 'media', 'light', 'class.svg')),

--- a/src/protocols.ts
+++ b/src/protocols.ts
@@ -35,8 +35,7 @@ export enum TestLevel {
     Folder = 1,
     Package = 2,
     Class = 3,
-    NestedClass = 4,
-    Method = 5,
+    Method = 4,
 }
 
 export enum TestKind {

--- a/src/runners/junit5Runner/JUnit5Runner.ts
+++ b/src/runners/junit5Runner/JUnit5Runner.ts
@@ -18,7 +18,7 @@ export class JUnit5Runner extends BaseRunner {
     private constructParamsForTests(): string[] {
         const params: string[] = [];
         for (const test of this.tests) {
-            if (test.level === TestLevel.Class || test.level === TestLevel.NestedClass) {
+            if (test.level === TestLevel.Class) {
                 params.push('-c', test.fullName);
             } else if (test.level === TestLevel.Method) {
                 params.push('-m', `${test.fullName}(${test.paramTypes.join(',')})`);


### PR DESCRIPTION
There is no need to differentiate `Class` and `Nested Class`

Since most of the resolving logic is the same.