### PR TITLE
fix: Test report will just update instead of changing the column if it's already opened

### DIFF
--- a/src/testReportProvider.ts
+++ b/src/testReportProvider.ts
@@ -75,7 +75,7 @@ class TestReportProvider implements Disposable {
 
         this.panel.webview.html = await testReportProvider.provideHtmlContent(tests);
 
-        this.panel.reveal(position);
+        this.panel.reveal(this.panel.viewColumn || position);
     }
 
     public async update(tests: ITestResult[]): Promise<void> {


### PR DESCRIPTION
Fix #727

If the report is already opened, just update it instead of changing its position.