### PR TITLE
fix: Clear the results before running tests

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -231,7 +231,8 @@ public class TestSearchUtils {
         for (final TestItem testClass : classMap.values()) {
             if (testClass.getChildren() == null || testClass.getChildren().size() <= 0) {
                 searchResult.add(testClass);
-            } else if (testClass.getChildren().size() == 1) {
+            } else if (testClass.getChildren().size() == 1 && params.getLevel() == TestLevel.METHOD) {
+                // If test level is method, only add the method into the result instead of the class
                 searchResult.add(testClass.getChildren().get(0));
             } else {
                 // Assume the kinds of all methods are the same.

--- a/src/runners/junit5Runner/JUnit5Runner.ts
+++ b/src/runners/junit5Runner/JUnit5Runner.ts
@@ -12,7 +12,7 @@ export class JUnit5Runner extends BaseRunner {
         if (!this.hasClassNameParam()) {
             // Set --include-classname to '.*' to treat all class name as valid test class.
             // See: https://github.com/microsoft/vscode-java-test/issues/381.
-            params.push('--include-classname', '.*');
+            params.push('--include-classname', '".*"');
         }
 
         params.push(...this.constructParamsForTests());

--- a/src/testResultManager.ts
+++ b/src/testResultManager.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { Disposable, Uri, WorkspaceFolder } from 'vscode';
 import { ITestResult, ITestResultDetails } from './runners/models';
 import { getTestSourcePaths } from './utils/commandUtils';
+import { isTestMethodName } from './utils/protocolUtils';
 
 class TestResultManager implements Disposable {
     private testResultMap: Map<string, Map<string, ITestResultDetails>> = new Map<string, Map<string, ITestResultDetails>>();
@@ -35,6 +36,27 @@ class TestResultManager implements Disposable {
             return resultsInFsPath.get(testFullName);
         }
         return undefined;
+    }
+
+    public removeResultDetails(fsPath: string, testFullName: string): void {
+        const resultsInFsPath: Map<string, ITestResultDetails> | undefined = this.getResults(fsPath);
+        if (resultsInFsPath) {
+            resultsInFsPath.delete(testFullName);
+        }
+    }
+
+    public removeResultDetailsUnderTheClass(fsPath: string, testFullName: string): void {
+        if (isTestMethodName(testFullName)) {
+            return;
+        }
+        const resultsInFsPath: Map<string, ITestResultDetails> | undefined = this.getResults(fsPath);
+        if (resultsInFsPath) {
+            for (const key of resultsInFsPath.keys()) {
+                if (key.startsWith(testFullName)) {
+                    resultsInFsPath.delete(key);
+                }
+            }
+        }
     }
 
     public getResults(fsPath: string): Map<string, ITestResultDetails> | undefined {

--- a/src/utils/protocolUtils.ts
+++ b/src/utils/protocolUtils.ts
@@ -19,3 +19,7 @@ export function constructSearchTestItemParams(node?: TestTreeNode): ISearchTestI
         fullName: '',
     };
 }
+
+export function isTestMethodName(fullName: string): boolean {
+    return fullName.includes('#');
+}


### PR DESCRIPTION
Fix #42

> Note: The change `'.*'` -> `"'.*'"` is to fix a regression involved in #730 