### PR TITLE
fix: When expanding the explorer, got the error: Property must not be null: range

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
@@ -59,7 +59,7 @@ public class TestItemUtils {
             final ISourceRange range = ((ISourceReference) element).getNameRange();
             return JDTUtils.toRange(element.getOpenable(), range.getOffset(), range.getLength());
         }
-        return null;
+        return new Range();
     }
 
     private static String parseTestItemFullName(IJavaElement element, TestLevel level) {


### PR DESCRIPTION
fix #749 