### PR TITLE
fix: Cannot find the class which annotated with @Runwith

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestFrameworkUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestFrameworkUtils.java
@@ -70,7 +70,12 @@ public class TestFrameworkUtils {
             return Optional.empty();
         }
 
-        final IType declaringType = member.getDeclaringType();
+        IType declaringType = null;
+        if (IMethod.class.isInstance(member)) {
+            declaringType = member.getDeclaringType();
+        } else if (IType.class.isInstance(member)) {
+            declaringType = (IType) member;
+        }
         if (declaringType == null) {
             return Optional.empty();
         }


### PR DESCRIPTION
This is a regression issue introduced when supporting the meta-annotation.