### PR TITLE
fix: Change the explorer name and the activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "onLanguage:java",
         "workspaceContains:pom.xml",
         "workspaceContains:build.gradle",
+        "onView:testExplorer",
         "onCommand:java.test.explorer.refresh",
         "onCommand:java.test.explorer.run",
         "onCommand:java.test.explorer.debug",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "onLanguage:java",
         "workspaceContains:pom.xml",
         "workspaceContains:build.gradle",
-        "onView:testExplorer",
         "onCommand:java.test.explorer.refresh",
         "onCommand:java.test.explorer.run",
         "onCommand:java.test.explorer.debug",
@@ -52,7 +51,7 @@
             "test": [
                 {
                     "id": "testExplorer",
-                    "name": "%contributes.views.explorer.testExplorer.name%"
+                    "name": "Java"
                 }
             ]
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,5 @@
 {
     "description": "Run and debug JUnit or TestNG test cases",
-    "contributes.views.explorer.testExplorer.name": "Test Explorer",
     "contributes.commands.java.test.show.output.title": "Show Test Output",
     "contributes.commands.java.test.open.log.title": "Open Test Runner Log",
     "contributes.commands.java.test.explorer.run.title": "Run Test",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -1,6 +1,5 @@
 {
     "description": "运行并调试 JUnit 或 TestNG 测试用例",
-    "contributes.views.explorer.testExplorer.name": "测试管理器",
     "contributes.commands.java.test.show.output.title": "显示测试输出",
     "contributes.commands.java.test.open.log.title": "打开测试运行日志",
     "contributes.commands.java.test.explorer.run.title": "运行测试用例",


### PR DESCRIPTION
Related with #793 

Change the explorer name to Java.
  - Since the `test` is a dependent panel and all languages can register their test explorers in there. So we should name it to specific `Java` instead  of general `test explorer`