### PR TITLE
refactor: Change to API of scheduler

### DIFF
--- a/src/commands/explorerCommands.ts
+++ b/src/commands/explorerCommands.ts
@@ -4,7 +4,7 @@
 import { CancellationToken, Progress, ProgressLocation, Range, TextDocument, Uri, ViewColumn, window, workspace } from 'vscode';
 import { TestTreeNode } from '../explorer/TestTreeNode';
 import { logger } from '../logger/logger';
-import { ISearchTestItemParams, ITestItem } from '../protocols';
+import { ISearchTestItemParams, ITestItem, TestLevel } from '../protocols';
 import { runnerScheduler } from '../runners/runnerScheduler';
 import { searchTestItemsAll } from '../utils/commandUtils';
 import { constructSearchTestItemParams } from '../utils/protocolUtils';
@@ -23,25 +23,36 @@ export async function debugTestsFromExplorer(node?: TestTreeNode): Promise<void>
 }
 
 async function executeTestsFromExplorer(isDebug: boolean, node?: TestTreeNode): Promise<void> {
-    let tests: ITestItem[] = [];
-    const searchParam: ISearchTestItemParams = constructSearchTestItemParams(node);
-    await window.withProgress(
-        { location: ProgressLocation.Notification, cancellable: true },
-        async (progress: Progress<any>, token: CancellationToken): Promise<void> => {
-            progress.report({ message: 'Searching test items...' });
-            tests = await searchTestItemsAll(searchParam);
-            if (token.isCancellationRequested) {
-                tests = [];
-                logger.info('Test job is canceled.');
-                return;
-            }
-            if (tests.length === 0) {
-                logger.info('No test items found.');
-                return;
-            }
-        },
-    );
-    if (tests.length > 0) {
-        return runnerScheduler.run(tests, isDebug, searchParam);
+    if (!node) {
+        node = new TestTreeNode('', '', TestLevel.Root, '');
     }
+    const tests: ITestItem[] = await searchTestItems(node);
+    if (tests.length <= 0) {
+        logger.info('No test items found.');
+        return;
+    }
+
+    return runnerScheduler.run(tests, isDebug, node);
 }
+
+async function searchTestItems(node: TestTreeNode): Promise<ITestItem[]> {
+    return new Promise<ITestItem[]>((resolve: (result: ITestItem[]) => void): void => {
+        const searchParam: ISearchTestItemParams = constructSearchTestItemParams(node);
+        window.withProgress(
+            { location: ProgressLocation.Notification, cancellable: true },
+            async (progress: Progress<any>, token: CancellationToken): Promise<void> => {
+                progress.report({ message: 'Searching test items...' });
+                const tests: ITestItem[] = await searchTestItemsAll(searchParam);
+                if (token.isCancellationRequested) {
+                    logger.info('Test job is canceled.');
+                    return resolve([]);
+                }
+                return resolve(tests);
+            },
+        );
+    });
+}
+
+// export async function runExeternalTestRequest(node: TestTreeNode, launchConfiguration: DebugConfiguration, isDebug: boolean = false) : Promise<void> {
+
+// }

--- a/src/commands/explorerCommands.ts
+++ b/src/commands/explorerCommands.ts
@@ -52,7 +52,3 @@ async function searchTestItems(node: TestTreeNode): Promise<ITestItem[]> {
         );
     });
 }
-
-// export async function runExeternalTestRequest(node: TestTreeNode, launchConfiguration: DebugConfiguration, isDebug: boolean = false) : Promise<void> {
-
-// }

--- a/src/runners/ITestRunner.ts
+++ b/src/runners/ITestRunner.ts
@@ -2,12 +2,13 @@
 // Licensed under the MIT license.
 
 import { DebugConfiguration } from 'vscode';
-import { ISearchTestItemParams, ITestItem } from '../protocols';
+import { TestTreeNode } from '../explorer/TestTreeNode';
+import { ITestItem } from '../protocols';
 import { IExecutionConfig } from '../runConfigs';
 import { ITestResult } from './models';
 
 export interface ITestRunner {
-    setup(tests: ITestItem[], isDebug: boolean, config?: IExecutionConfig, searchParam?: ISearchTestItemParams): Promise<DebugConfiguration>;
+    setup(tests: ITestItem[], isDebug: boolean, config?: IExecutionConfig, node?: TestTreeNode): Promise<DebugConfiguration>;
     run(launchConfiguration: DebugConfiguration): Promise<ITestResult[]>;
     tearDown(isCancel: boolean): Promise<void>;
 }

--- a/src/runners/junit4Runner/Junit4Runner.ts
+++ b/src/runners/junit4Runner/Junit4Runner.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT license.
 
 import { debug, DebugConfiguration, Uri, workspace } from 'vscode';
-import { ISearchTestItemParams, ITestItem } from '../../protocols';
+import { TestTreeNode } from '../../explorer/TestTreeNode';
+import { ITestItem } from '../../protocols';
 import { IExecutionConfig } from '../../runConfigs';
 import { getDebugConfigurationForEclispeRunner as getEclispeJUnitRunnerLaunchConfig } from '../../utils/launchUtils';
 import { BaseRunner } from '../baseRunner/BaseRunner';
@@ -11,12 +12,12 @@ import { JUnit4RunnerResultAnalyzer } from './JUnit4RunnerResultAnalyzer';
 
 export class JUnit4Runner extends BaseRunner {
 
-    public async setup(tests: ITestItem[], isDebug: boolean = false, config?: IExecutionConfig, searchParam?: ISearchTestItemParams): Promise<DebugConfiguration> {
+    public async setup(tests: ITestItem[], isDebug: boolean = false, config?: IExecutionConfig, node?: TestTreeNode): Promise<DebugConfiguration> {
         await this.startSocketServer();
         this.clearTestResults(tests);
         this.tests = tests;
 
-        return getEclispeJUnitRunnerLaunchConfig(tests[0], this.server.address().port, isDebug, config, searchParam);
+        return getEclispeJUnitRunnerLaunchConfig(tests[0], this.server.address().port, isDebug, config, node);
     }
 
     protected get testResultAnalyzer(): BaseRunnerResultAnalyzer {

--- a/src/runners/runnerScheduler.ts
+++ b/src/runners/runnerScheduler.ts
@@ -7,8 +7,9 @@ import { showOutputChannel } from '../commands/logCommands';
 import { JavaLanguageServerCommands } from '../constants/commands';
 import { ReportShowSetting } from '../constants/configs';
 import { OPEN_OUTPUT_CHANNEL } from '../constants/dialogOptions';
+import { TestTreeNode } from '../explorer/TestTreeNode';
 import { logger } from '../logger/logger';
-import { ISearchTestItemParams, ITestItem, TestKind } from '../protocols';
+import { ITestItem, TestKind } from '../protocols';
 import { IExecutionConfig } from '../runConfigs';
 import { testReportProvider } from '../testReportProvider';
 import { testResultManager } from '../testResultManager';
@@ -33,7 +34,7 @@ class RunnerScheduler {
         this._context = context;
     }
 
-    public async run(testItems: ITestItem[], isDebug: boolean, searchParam?: ISearchTestItemParams): Promise<void> {
+    public async run(testItems: ITestItem[], isDebug: boolean, node?: TestTreeNode): Promise<void> {
         if (this._isRunning) {
             window.showInformationMessage('A test session is currently running. Please wait until it finishes.');
             return;
@@ -85,7 +86,7 @@ class RunnerScheduler {
                         token.onCancellationRequested(() => {
                             this.cleanUp(true /* isCancel */);
                         });
-                        const launchConfiguration: DebugConfiguration = await runner.setup(tests, isDebug, resolveVariablesInConfig(config, Uri.parse(tests[0].location.uri)), searchParam);
+                        const launchConfiguration: DebugConfiguration = await runner.setup(tests, isDebug, resolveVariablesInConfig(config, Uri.parse(tests[0].location.uri)), node);
                         testStatusBarProvider.showRunningTest();
                         progress.report({ message: 'Running tests...'});
                         if (token.isCancellationRequested) {

--- a/src/utils/protocolUtils.ts
+++ b/src/utils/protocolUtils.ts
@@ -5,18 +5,19 @@ import { Uri } from 'vscode';
 import { TestTreeNode } from '../explorer/TestTreeNode';
 import { ISearchTestItemParams, TestLevel } from '../protocols';
 
-export function constructSearchTestItemParams(node?: TestTreeNode): ISearchTestItemParams {
-    if (node) {
+export function constructSearchTestItemParams(node: TestTreeNode): ISearchTestItemParams {
+    if (node.level === TestLevel.Root) {
         return {
-            uri: Uri.file(node.fsPath).toString(),
-            level: node.level,
-            fullName: node.fullName,
+            uri: '',
+            level: TestLevel.Root,
+            fullName: '',
         };
     }
+
     return {
-        uri: '',
-        level: TestLevel.Root,
-        fullName: '',
+        uri: Uri.file(node.fsPath).toString(),
+        level: node.level,
+        fullName: node.fullName,
     };
 }
 


### PR DESCRIPTION
The original API accepts the `ISearchTestItemParams`. While, the new API accepts `TestTreeNode` instead. Which is easier to know that the task is triggered from Test Explorer or not.