### PR TITLE
Issue #835:  Making sure vscode cleans up the running test 

### DIFF
--- a/src/runners/runnerScheduler.ts
+++ b/src/runners/runnerScheduler.ts
@@ -51,6 +51,7 @@ class RunnerScheduler {
                     'Proceed',
                     'Abort');
                 if (ans !== 'Proceed') {
+                    this.cleanUp(false);
                     return;
                 }
             }


### PR DESCRIPTION
If a build fails and the user selects to Abort the running tests, the cleanup method is never called and the isRunning boolean is stranded as true.

This forces cleanup to occur if the user abandons their test run to fix build issues