### PR TITLE
Deprecate the setting 'java.test.forceBuildBeforeLaunchTest'

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,13 +205,6 @@
                     "description": "%configuration.java.test.saveAllBeforeLaunchTest.description%",
                     "scope": "application"
                 },
-                "java.test.forceBuildBeforeLaunchTest": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%configuration.java.test.forceBuildBeforeLaunchTest.description%",
-                    "scope": "application",
-                    "deprecationMessage": "%configuration.java.test.forceBuildBeforeLaunchTest.deprecationMessage%"
-                },
                 "java.test.log.level": {
                     "type": "string",
                     "enum": [

--- a/package.json
+++ b/package.json
@@ -207,9 +207,10 @@
                 },
                 "java.test.forceBuildBeforeLaunchTest": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "%configuration.java.test.forceBuildBeforeLaunchTest.description%",
-                    "scope": "application"
+                    "scope": "application",
+                    "deprecationMessage": "%configuration.java.test.forceBuildBeforeLaunchTest.deprecationMessage%"
                 },
                 "java.test.log.level": {
                     "type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,6 +14,7 @@
     "configuration.java.test.editor.enableShortcuts.description": "Specify whether to show the Code Lenses in editor or not",
     "configuration.java.test.saveAllBeforeLaunchTest.description": "Specify whether to save all of the dirty files before lauching the test",
     "configuration.java.test.forceBuildBeforeLaunchTest.description": "Specify whether to force build the workspace before launching the test",
+    "configuration.java.test.forceBuildBeforeLaunchTest.deprecationMessage": "Please use `java.debug.settings.forceBuildBeforeLaunch` instead",
     "configuration.java.test.log.level.description": "Specify the level of the test logs",
     "configuration.java.test.message.hintForDeprecatedConfig.description": "Specify whether the extension will show hint dialog when deprecated configuration file is used",
     "configuration.java.test.message.hintForSetingDefaultConfig.description": "Specify whether the extension will show hint to set default test configuration",

--- a/package.nls.json
+++ b/package.nls.json
@@ -13,8 +13,6 @@
     "configuration.java.test.report.position.description": "Specify where to show the test report",
     "configuration.java.test.editor.enableShortcuts.description": "Specify whether to show the Code Lenses in editor or not",
     "configuration.java.test.saveAllBeforeLaunchTest.description": "Specify whether to save all of the dirty files before lauching the test",
-    "configuration.java.test.forceBuildBeforeLaunchTest.description": "Specify whether to force build the workspace before launching the test",
-    "configuration.java.test.forceBuildBeforeLaunchTest.deprecationMessage": "Please use `java.debug.settings.forceBuildBeforeLaunch` instead",
     "configuration.java.test.log.level.description": "Specify the level of the test logs",
     "configuration.java.test.message.hintForDeprecatedConfig.description": "Specify whether the extension will show hint dialog when deprecated configuration file is used",
     "configuration.java.test.message.hintForSetingDefaultConfig.description": "Specify whether the extension will show hint to set default test configuration",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -14,6 +14,7 @@
     "configuration.java.test.editor.enableShortcuts.description": "设定是否在编辑器内显示 Code Lens 快捷方式",
     "configuration.java.test.saveAllBeforeLaunchTest.description": "设定在执行测试之前是否需要保存工作空间内的所有文件",
     "configuration.java.test.forceBuildBeforeLaunchTest.description": "设定在执行测试之前是否需要构建工作空间",
+    "configuration.java.test.forceBuildBeforeLaunchTest.deprecationMessage": "请使用 `java.debug.settings.forceBuildBeforeLaunch` 进行相关配置",
     "configuration.java.test.log.level.description": "设定日志级别",
     "configuration.java.test.message.hintForDeprecatedConfig.description": "设定插件是否会对使用弃用的配置文件进行提示",
     "configuration.java.test.message.hintForSetingDefaultConfig.description": "设定插件是否会对设置默认测试配置项进行提示",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -13,8 +13,6 @@
     "configuration.java.test.report.position.description": "设定测试报告的显示位置",
     "configuration.java.test.editor.enableShortcuts.description": "设定是否在编辑器内显示 Code Lens 快捷方式",
     "configuration.java.test.saveAllBeforeLaunchTest.description": "设定在执行测试之前是否需要保存工作空间内的所有文件",
-    "configuration.java.test.forceBuildBeforeLaunchTest.description": "设定在执行测试之前是否需要构建工作空间",
-    "configuration.java.test.forceBuildBeforeLaunchTest.deprecationMessage": "请使用 `java.debug.settings.forceBuildBeforeLaunch` 进行相关配置",
     "configuration.java.test.log.level.description": "设定日志级别",
     "configuration.java.test.message.hintForDeprecatedConfig.description": "设定插件是否会对使用弃用的配置文件进行提示",
     "configuration.java.test.message.hintForSetingDefaultConfig.description": "设定插件是否会对设置默认测试配置项进行提示",

--- a/src/constants/configs.ts
+++ b/src/constants/configs.ts
@@ -5,8 +5,6 @@ export const LOCAL_HOST: string = '127.0.0.1';
 
 export const SAVE_ALL_BEFORE_LAUNCH_SETTING_KEY: string = 'java.test.saveAllBeforeLaunchTest';
 
-export const BUILD_BEFORE_LAUNCH_SETTING_KEY: string = 'java.test.forceBuildBeforeLaunchTest';
-
 export const LOG_FILE_NAME: string = 'java_test_runner.log';
 export const LOG_FILE_MAX_SIZE: number = 5 * 1024 * 1024;
 export const LOG_FILE_MAX_NUMBER: number = 2;

--- a/src/runners/runnerScheduler.ts
+++ b/src/runners/runnerScheduler.ts
@@ -2,9 +2,8 @@
 // Licensed under the MIT license.
 
 import * as _ from 'lodash';
-import { commands, DebugConfiguration, ExtensionContext, Uri, window, workspace, WorkspaceFolder } from 'vscode';
+import { DebugConfiguration, ExtensionContext, Uri, window, workspace, WorkspaceFolder } from 'vscode';
 import { testCodeLensController } from '../codelens/TestCodeLensController';
-import { JavaLanguageServerCommands } from '../constants/commands';
 import { ReportShowSetting } from '../constants/configs';
 import { logger } from '../logger/logger';
 import { ITestItem, TestKind } from '../protocols';
@@ -14,7 +13,7 @@ import { testResultManager } from '../testResultManager';
 import { testStatusBarProvider } from '../testStatusBarProvider';
 import { getResolvedRunConfig } from '../utils/configUtils';
 import { resolveLaunchConfigurationForRunner } from '../utils/launchUtils';
-import { getShowReportSetting, needBuildWorkspace, needSaveAll } from '../utils/settingUtils';
+import { getShowReportSetting, needSaveAll } from '../utils/settingUtils';
 import * as uiUtils from '../utils/uiUtils';
 import { BaseRunner } from './baseRunner/BaseRunner';
 import { JUnitRunner } from './junitRunner/JunitRunner';
@@ -40,21 +39,6 @@ class RunnerScheduler {
         let finalResults: ITestResult[] = [];
 
         await this.saveFilesIfNeeded();
-
-        if (needBuildWorkspace()) {
-            try {
-                // Directly call this Language Server command since we hard depend on it.
-                await commands.executeCommand(JavaLanguageServerCommands.JAVA_BUILD_WORKSPACE, false /*incremental build*/);
-            } catch (err) {
-                const ans: string | undefined = await window.showErrorMessage(
-                    'Build failed, do you want to continue?',
-                    'Proceed',
-                    'Abort');
-                if (ans !== 'Proceed') {
-                    return;
-                }
-            }
-        }
 
         try {
             this._runnerMap = this.classifyTestsByKind(testItems);

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -3,7 +3,7 @@
 
 import * as _ from 'lodash';
 import { Uri, ViewColumn, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
-import { BUILD_BEFORE_LAUNCH_SETTING_KEY, DEFAULT_LOG_LEVEL, DEFAULT_REPORT_POSITION, DEFAULT_REPORT_SHOW, LOG_LEVEL_SETTING_KEY, REPORT_POSITION_SETTING_KEY, REPORT_SHOW_SETTING_KEY, SAVE_ALL_BEFORE_LAUNCH_SETTING_KEY } from '../constants/configs';
+import { DEFAULT_LOG_LEVEL, DEFAULT_REPORT_POSITION, DEFAULT_REPORT_SHOW, LOG_LEVEL_SETTING_KEY, REPORT_POSITION_SETTING_KEY, REPORT_SHOW_SETTING_KEY, SAVE_ALL_BEFORE_LAUNCH_SETTING_KEY } from '../constants/configs';
 import { logger } from '../logger/logger';
 import { IExecutionConfig } from '../runConfigs';
 
@@ -15,10 +15,6 @@ export function getReportPosition(): ViewColumn {
 
 export function needSaveAll(): boolean {
     return workspace.getConfiguration().get<boolean>(SAVE_ALL_BEFORE_LAUNCH_SETTING_KEY, true);
-}
-
-export function needBuildWorkspace(): boolean {
-    return workspace.getConfiguration().get<boolean>(BUILD_BEFORE_LAUNCH_SETTING_KEY, true);
 }
 
 export function getLogLevel(): string {


### PR DESCRIPTION
We don't need this setting any more because we are fully leverage the debugger to launch the tests now.

![image](https://user-images.githubusercontent.com/6193897/67448518-c9c9c580-f649-11e9-91f1-6d2c7a812474.png)

![image](https://user-images.githubusercontent.com/6193897/67448527-d3532d80-f649-11e9-89c8-cb895fca62e9.png)
