### PR TITLE
Better handling the cancel event

### DIFF
--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -3,7 +3,6 @@
 
 export namespace JavaLanguageServerCommands {
     export const EXECUTE_WORKSPACE_COMMAND: string = 'java.execute.workspaceCommand';
-    export const JAVA_BUILD_WORKSPACE: string = 'java.workspace.compile';
 }
 
 export namespace JavaTestRunnerDelegateCommands {
@@ -22,8 +21,6 @@ export namespace JavaTestRunnerCommands {
     export const DEBUG_TEST_FROM_CODELENS: string = 'java.test.debug';
     export const RUN_TEST_FROM_EXPLORER: string = 'java.test.explorer.run';
     export const DEBUG_TEST_FROM_EXPLORER: string = 'java.test.explorer.debug';
-    export const RUN_TEST_WITH_CONFIG_FROM_EXPLORER: string = 'java.test.explorer.run.config';
-    export const DEBUG_TEST_WITH_CONFIG_FROM_EXPLORER: string = 'java.test.explorer.debug.config';
     export const SHOW_TEST_REPORT: string = 'java.test.show.report';
     export const SHOW_TEST_OUTPUT: string = 'java.test.show.output';
     export const OPEN_TEST_LOG: string = 'java.test.open.log';


### PR DESCRIPTION
The previous implementation will return `[]` on cancel. Cause the output channel having:
both `Test job is canceled.` & `'No test items found.'` when the user click cancel.