### PR TITLE
refactor: Stop resolving the variables in launch configuration

### DIFF
--- a/src/runners/runnerScheduler.ts
+++ b/src/runners/runnerScheduler.ts
@@ -11,7 +11,7 @@ import { IExecutionConfig } from '../runConfigs';
 import { testReportProvider } from '../testReportProvider';
 import { testResultManager } from '../testResultManager';
 import { testStatusBarProvider } from '../testStatusBarProvider';
-import { getResolvedRunConfig } from '../utils/configUtils';
+import { loadRunConfig } from '../utils/configUtils';
 import { resolveLaunchConfigurationForRunner } from '../utils/launchUtils';
 import { getShowReportSetting } from '../utils/settingUtils';
 import * as uiUtils from '../utils/uiUtils';
@@ -43,7 +43,7 @@ class RunnerScheduler {
             for (const [runner, tests] of this._runnerMap.entries()) {
                 // The test items that belong to a test runner, here the test items should be in the same workspace folder.
                 const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(Uri.parse(tests[0].location.uri));
-                const config: IExecutionConfig | undefined = await getResolvedRunConfig(workspaceFolder);
+                const config: IExecutionConfig | undefined = await loadRunConfig(workspaceFolder);
                 if (!config) {
                     logger.info('Test job is canceled.');
                     continue;

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -10,21 +10,13 @@ import { BUILTIN_CONFIG_NAME, CONFIG_DOCUMENT_URL, CONFIG_SETTING_KEY, DEFAULT_C
 import { LEARN_MORE, NEVER_SHOW, NO, OPEN_SETTING, YES } from '../constants/dialogOptions';
 import { logger } from '../logger/logger';
 import { getBuiltinConfig, IExecutionConfig, ITestConfig } from '../runConfigs';
-import { resolveVariablesInConfig } from './settingUtils';
 
-export async function getResolvedRunConfig(workspaceFolder: WorkspaceFolder | undefined): Promise<IExecutionConfig | undefined> {
+export async function loadRunConfig(workspaceFolder: WorkspaceFolder | undefined): Promise<IExecutionConfig | undefined> {
     if (!workspaceFolder) {
         window.showErrorMessage('Failed to get workspace folder for the test items.');
         return undefined;
     }
-    const config: IExecutionConfig | undefined = await loadRunConfig(workspaceFolder);
-    if (!config) {
-        return undefined;
-    }
-    return resolveVariablesInConfig(config, workspaceFolder.uri);
-}
 
-async function loadRunConfig(workspaceFolder: WorkspaceFolder): Promise<IExecutionConfig | undefined> {
     const configSetting: IExecutionConfig[] | IExecutionConfig = workspace.getConfiguration(undefined, workspaceFolder.uri).get<IExecutionConfig[] | IExecutionConfig>(CONFIG_SETTING_KEY, {});
     if (!_.isEmpty(configSetting)) {
         // Use the new config schema

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as _ from 'lodash';
 import { ViewColumn, workspace, WorkspaceConfiguration } from 'vscode';
 import { DEFAULT_LOG_LEVEL, DEFAULT_REPORT_POSITION, DEFAULT_REPORT_SHOW, LOG_LEVEL_SETTING_KEY, REPORT_POSITION_SETTING_KEY, REPORT_SHOW_SETTING_KEY } from '../constants/configs';
 

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -2,10 +2,8 @@
 // Licensed under the MIT license.
 
 import * as _ from 'lodash';
-import { Uri, ViewColumn, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+import { ViewColumn, workspace, WorkspaceConfiguration } from 'vscode';
 import { DEFAULT_LOG_LEVEL, DEFAULT_REPORT_POSITION, DEFAULT_REPORT_SHOW, LOG_LEVEL_SETTING_KEY, REPORT_POSITION_SETTING_KEY, REPORT_SHOW_SETTING_KEY } from '../constants/configs';
-import { logger } from '../logger/logger';
-import { IExecutionConfig } from '../runConfigs';
 
 export function getReportPosition(): ViewColumn {
     const config: WorkspaceConfiguration = workspace.getConfiguration();
@@ -19,61 +17,4 @@ export function getLogLevel(): string {
 
 export function getShowReportSetting(): string {
     return workspace.getConfiguration().get<string>(REPORT_SHOW_SETTING_KEY, DEFAULT_REPORT_SHOW);
-}
-
-const workspaceRegexp: RegExp = /\$\{workspacefolder\}/i;
-export function resolveVariablesInConfig(config: IExecutionConfig, uri: Uri): IExecutionConfig {
-    const resolvedConfig: IExecutionConfig = {};
-    const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(uri);
-    if (!workspaceFolder) {
-        logger.error(`Failed to parse the working directory for test: ${uri}`);
-        return config;
-    }
-
-    if (config.workingDirectory) {
-        if (workspaceRegexp.test(config.workingDirectory)) {
-            resolvedConfig.workingDirectory = config.workingDirectory.replace(workspaceRegexp, workspaceFolder.uri.fsPath);
-        } else {
-            resolvedConfig.workingDirectory = config.workingDirectory;
-        }
-    }
-
-    if (config.args) {
-        resolvedConfig.args = [];
-        for (const arg of config.args) {
-            if (needResolve(arg)) {
-                resolvedConfig.args.push(arg.replace(workspaceRegexp, workspaceFolder.uri.fsPath));
-            } else {
-                resolvedConfig.args.push(arg);
-            }
-        }
-    }
-
-    if (config.vmargs) {
-        resolvedConfig.vmargs = [];
-        for (const vmarg of config.vmargs as string[]) {
-            if (needResolve(vmarg)) {
-                resolvedConfig.vmargs.push(vmarg.replace(workspaceRegexp, workspaceFolder.uri.fsPath));
-            } else {
-                resolvedConfig.vmargs.push(vmarg);
-            }
-        }
-    }
-
-    if (config.env) {
-        resolvedConfig.env = {};
-        for (const key of Object.keys(config.env)) {
-            if (needResolve(config.env[key])) {
-                resolvedConfig.env[key] = config.env[key].replace(workspaceRegexp, workspaceFolder.uri.fsPath);
-            } else {
-                resolvedConfig.env[key] = config.env[key];
-            }
-        }
-    }
-
-    return resolvedConfig;
-}
-
-function needResolve(value: any): boolean {
-    return _.isString(value) && workspaceRegexp.test(value);
 }


### PR DESCRIPTION
The reason to remove the resolving logic is that we now fully leverage the Java debugger to launch the tests. Thus the Java debugger will help resolving those variables.