### PR TITLE
Use StandardClasspathProvider to resolve classpath for Gradle project

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfiguration.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfiguration.java
@@ -48,7 +48,7 @@ public class JUnitLaunchConfiguration extends LaunchConfiguration {
             classpathProvider = "org.eclipse.m2e.launchconfig.classpathProvider";
             sourcepathProvider = "org.eclipse.m2e.launchconfig.sourcepathProvider";
         } else if (ProjectUtils.isGradleProject(testInfo.project)) {
-            classpathProvider = "org.eclipse.buildship.core.classpathprovider";
+            // Use StandardClasspathProvider for Gradle project
         }
         this.testInfo = testInfo;
     }


### PR DESCRIPTION
fix #872 

The GradleClasspathProvider could not handle the modular project well. Just use the default classpath provider to resolve the classpath and modulepath.