### PR TITLE
bugfix: Cannot trigger test from explorer

### DIFF
--- a/src/commands/runFromCodeLens.ts
+++ b/src/commands/runFromCodeLens.ts
@@ -10,9 +10,12 @@ export async function runFromCodeLens(test: ITestItem, isDebug: boolean): Promis
         scope: test.level,
         testUri: test.location.uri,
         fullName: test.fullName,
+        paramTypes: test.paramTypes,
+        kind: test.kind,
         projectName: test.project,
+        tests: [test],
         isDebug,
     };
 
-    await runnerScheduler.run([test], runnerContext);
+    await runnerScheduler.run(runnerContext);
 }

--- a/src/runners/models.ts
+++ b/src/runners/models.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { TestLevel } from '../protocols';
+import { ITestItem, TestKind, TestLevel } from '../protocols';
 
 export interface ITestResult {
     id: string;
@@ -32,6 +32,9 @@ export interface IRunnerContext {
     scope: TestLevel;
     testUri: string;
     fullName: string;
+    paramTypes: string[];
     projectName: string;
     isDebug: boolean;
+    kind: TestKind;
+    tests?: ITestItem[];
 }

--- a/src/testItemModel.ts
+++ b/src/testItemModel.ts
@@ -26,15 +26,15 @@ class TestItemModel implements Disposable {
     }
 
     public async getNodeChildren(parent: ITestItem): Promise<ITestItem[]> {
-        const searchParams: ISearchTestItemParams = constructSearchTestItemParams(parent);
+        const searchParams: ISearchTestItemParams = constructSearchTestItemParams(parent.level, parent.fullName, parent.location.uri);
         const responses: ITestItem[] = await searchTestItems(searchParams);
         parent.children = responses.map((child: ITestItem) => child.id);
         this.save([...responses, parent]);
         return responses;
     }
 
-    public async getAllNodes(node: ITestItem): Promise<ITestItem[]> {
-        const searchParam: ISearchTestItemParams = constructSearchTestItemParams(node);
+    public async getAllNodes(level: TestLevel, fullName: string, uri: string): Promise<ITestItem[]> {
+        const searchParam: ISearchTestItemParams = constructSearchTestItemParams(level, fullName, uri);
         const tests: ITestItem[] = await searchTestItemsAll(searchParam);
         this.save(tests);
         return tests;

--- a/src/utils/protocolUtils.ts
+++ b/src/utils/protocolUtils.ts
@@ -1,21 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { ISearchTestItemParams, ITestItem, TestLevel } from '../protocols';
+import { ISearchTestItemParams, TestLevel } from '../protocols';
 
-export function constructSearchTestItemParams(node: ITestItem): ISearchTestItemParams {
-    if (node.level === TestLevel.Root) {
+export function constructSearchTestItemParams(level: TestLevel, fullName: string, uri: string): ISearchTestItemParams {
+    if (level === TestLevel.Root) {
         return {
             uri: '',
-            level: TestLevel.Root,
+            level,
             fullName: '',
         };
     }
 
     return {
-        uri: node.location.uri,
-        level: node.level,
-        fullName: node.fullName,
+        uri,
+        level,
+        fullName,
     };
 }
 


### PR DESCRIPTION
fix #911 

By fixing this bug, also did some refactoring work that save the required information in the `runnerContext`, which is to avoid passing the `test items` deeper in the function calls.