### PR TITLE
refactor: Move the test item node cache from explorer to model layer

### DIFF
--- a/src/explorer/testExplorer.ts
+++ b/src/explorer/testExplorer.ts
@@ -16,7 +16,6 @@ export class TestExplorer implements TreeDataProvider<ITestItem>, Disposable {
     // tslint:disable-next-line:member-ordering
     public readonly onDidChangeTreeData: Event<ITestItem | null | undefined> = this.onDidChangeTreeDataEventEmitter.event;
 
-    private fsPathToNodeMapping: Map<string, ITestItem> = new Map<string, ITestItem>();
     private _context: ExtensionContext;
 
     public initialize(context: ExtensionContext): void {
@@ -40,30 +39,14 @@ export class TestExplorer implements TreeDataProvider<ITestItem>, Disposable {
         } else {
             nodes = await testItemModel.getNodeChildren(element);
         }
-        if (element && element.level === TestLevel.Package) {
-            // Only save the first level classes since method and inner classes will have the same uri
-            for (const child of nodes) {
-                if (child.level === TestLevel.Class) {
-                    this.fsPathToNodeMapping.set(Uri.parse(child.location.uri).fsPath, child);
-                }
-            }
-        }
         return nodes.sort((a: ITestItem, b: ITestItem) => a.displayName.localeCompare(b.displayName));
     }
 
     public refresh(element?: ITestItem): void {
-        if (!element) {
-            this.fsPathToNodeMapping.clear();
-        }
         this.onDidChangeTreeDataEventEmitter.fire(element);
     }
 
-    public getNodeByFsPath(fsPath: string): ITestItem | undefined {
-        return this.fsPathToNodeMapping.get(fsPath);
-    }
-
     public dispose(): void {
-        this.fsPathToNodeMapping.clear();
         this.onDidChangeTreeDataEventEmitter.dispose();
     }
 

--- a/src/testItemModel.ts
+++ b/src/testItemModel.ts
@@ -9,45 +9,91 @@ import { constructSearchTestItemParams } from './utils/protocolUtils';
 class TestItemModel implements Disposable {
 
     private store: Map<string, ITestItem> = new Map<string, ITestItem>();
+    private idMappedByFsPath: Map<string, Set<string>> = new Map<string, Set<string>>();
 
     public getItemById(id: string): ITestItem | undefined {
         return this.store.get(id);
     }
 
-    public save(items: ITestItem[]): void {
-        for (const item of items) {
-            if (item.level < TestLevel.Class) {
-                // Only class and method will have the test result.
-                continue;
-            }
-
-            this.store.set(item.id, Object.assign({}, this.store.get(item.id), item));
-        }
-    }
-
     public async getNodeChildren(parent: ITestItem): Promise<ITestItem[]> {
         const searchParams: ISearchTestItemParams = constructSearchTestItemParams(parent.level, parent.fullName, parent.location.uri);
-        const responses: ITestItem[] = await searchTestItems(searchParams);
-        parent.children = responses.map((child: ITestItem) => child.id);
-        this.save([...responses, parent]);
-        return responses;
+        const childrenNodes: ITestItem[] = await searchTestItems(searchParams);
+        parent.children = childrenNodes.map((child: ITestItem) => child.id);
+        this.save([parent]);
+        return this.save(childrenNodes);
     }
 
     public async getAllNodes(level: TestLevel, fullName: string, uri: string): Promise<ITestItem[]> {
         const searchParam: ISearchTestItemParams = constructSearchTestItemParams(level, fullName, uri);
         const tests: ITestItem[] = await searchTestItemsAll(searchParam);
-        this.save(tests);
-        return tests;
+        return this.save(tests);
     }
 
     public async getItemsForCodeLens(uri: Uri): Promise<ITestItem[]> {
         const result: ITestItem[] = await searchTestCodeLens(uri.toString());
-        this.save(result);
-        return result;
+        return this.save(result);
+    }
+
+    public getItemsByFsPath(fsPath: string): ITestItem[] {
+        const res: ITestItem[] = [];
+        const idSet: Set<string> | undefined = this.idMappedByFsPath.get(fsPath);
+        if (idSet) {
+            for (const id of idSet) {
+                const item: ITestItem | undefined = this.store.get(id);
+                if (!item) {
+                    continue;
+                }
+                res.push(item);
+            }
+        }
+        return res;
+    }
+
+    public removeTestItemById(id: string): boolean {
+        return this.store.delete(id);
+    }
+
+    public removeIdMappingByFsPath(fsPath: string): boolean {
+        return this.idMappedByFsPath.delete(fsPath);
     }
 
     public dispose(): void {
         this.store.clear();
+        this.idMappedByFsPath.clear();
+    }
+
+    private save(items: ITestItem[]): ITestItem[] {
+        const storedItems: ITestItem[] = [];
+        for (const item of items) {
+            if (item.level < TestLevel.Class) {
+                // Only save class and method since they have the test results,
+                // still push the items into the returned array to let explorer show them.
+                storedItems.push(item);
+                continue;
+            }
+
+            let storedItem: ITestItem | undefined = this.store.get(item.id);
+            if (storedItem) {
+                storedItem = Object.assign(storedItem, item);
+            } else {
+                storedItem = Object.assign({}, item);
+            }
+            this.store.set(item.id, storedItem);
+            this.updateIdMapping(item);
+            storedItems.push(storedItem);
+        }
+
+        return storedItems;
+    }
+
+    private updateIdMapping(item: ITestItem): void {
+        const fsPath: string = Uri.parse(item.location.uri).fsPath;
+        const testSet: Set<string> | undefined = this.idMappedByFsPath.get(fsPath);
+        if (testSet) {
+            testSet.add(item.id);
+        } else {
+            this.idMappedByFsPath.set(fsPath, new Set([item.id]));
+        }
     }
 }
 


### PR DESCRIPTION
This PR does the following two things:

1. Move the `fsPathToNodeMapping` from explorer to `testItemModel`. Since the model layer should be the place to cache the testItems.

2. When saving the test items, always return the object reference instead a new object. This is for incremental update purpose of the test explorer