### PR TITLE
fix: Improve the test report style

### DIFF
--- a/resources/templates/report_method_table.pug
+++ b/resources/templates/report_method_table.pug
@@ -5,16 +5,16 @@ mixin collapseMethodTable(children, type)
         - classIdx++
         ul.list-group.mb-3
             li.list-group-item.active
-                h5.mb-0 #{entry[0]}
+                h5.mb-0.text-truncate-left #{entry[0]}
             - var methodIdx = 0
             each method in entry[1]
                 - methodIdx++
                 li.list-group-item.list-group-item-action
                     div.row.accordion-toggle
-                        div.col-8.collapsed(data-toggle="collapse", data-target=`#${type}-${classIdx}-${methodIdx}`, style="cursor:pointer", title="View details")
+                        div.col-8.text-truncate.collapsed(data-toggle="collapse", data-target=`#${type}-${classIdx}-${methodIdx}`, style="cursor:pointer", title="View details")
                             include /images/chevron-right.svg
                             span.ml-1 #{method.displayName}
-                        div.col-1.text-right
+                        div.col-1.text-right.p-0
                             if !method.status
                                 span.badge.badge-warning Not run
                             else if method.status === 'Pass'
@@ -23,8 +23,8 @@ mixin collapseMethodTable(children, type)
                                 span.badge.badge-danger Failed
                             else
                                 span.badge.badge-secondary Skipped
-                        div.col-2.text-right #{method.duration >= 0 ? method.duration + "ms" : "N/A"}
-                        div.col-1.text-right
+                        div.col-2.text-right #{method.duration >= 0 ? parseFloat((method.duration/1000).toFixed(2)) + "s" : "N/A"}
+                        div.col-1.text-right.pl-0
                             a(href="#", title="Navigate to Source", uri=`${method.location && method.location.uri ? method.location.uri : ''}`, range=`${method.location && method.location.range ? JSON.stringify(method.location.range) : ''}`, fullname=`${method.fullName}`)
                                 include /images/go-to-file.svg
                     div.mt-2.pl-2.accordion-body(id=`${type}-${classIdx}-${methodIdx}`, class="collapse")
@@ -39,7 +39,7 @@ mixin collapseMethodTable(children, type)
                         div.row
                             div.col
                                 if method.trace
-                                    pre
-                                        code #{method.trace}
+                                    pre.pre-wrap
+                                        code.word-break-all  #{method.trace}
                                 else
                                     span N/A

--- a/resources/templates/scss/report.scss
+++ b/resources/templates/scss/report.scss
@@ -17,3 +17,18 @@ $pre-color: var(--vscode-foreground);
 $code-color: var(--vscode-foreground);
 
 @import "../../../node_modules/bootstrap/scss/bootstrap";
+
+
+.text-truncate-left {
+    @extend .text-truncate;
+    @extend .text-left;
+    direction: rtl;
+}
+
+code.word-break-all {
+    word-break: break-all;
+}
+
+pre.pre-wrap {
+    white-space: pre-wrap;
+}

--- a/resources/templates/scss/report.scss
+++ b/resources/templates/scss/report.scss
@@ -18,7 +18,6 @@ $code-color: var(--vscode-foreground);
 
 @import "../../../node_modules/bootstrap/scss/bootstrap";
 
-
 .text-truncate-left {
     @extend .text-truncate;
     @extend .text-left;


### PR DESCRIPTION
fix #939
fix #938
fix #933

This PR include the following change
- Wrap the word for the stacktrace area
- Add ellipsis style to The class and method name
- Change the time format from `ms` to `s`

![Kapture 2020-02-21 at 18 53 46](https://user-images.githubusercontent.com/6193897/75029217-9b1b0900-54dc-11ea-9b82-98603920695a.gif)
