### PR TITLE
set document selector with pattern string

### DIFF
--- a/src/codelens/TestCodeLensController.ts
+++ b/src/codelens/TestCodeLensController.ts
@@ -31,7 +31,7 @@ class TestCodeLensController implements Disposable {
             return {
                 language: 'java',
                 scheme: 'file',
-                pattern: p,
+                pattern: p.pattern,
             };
         });
 


### PR DESCRIPTION
Fix for issue https://github.com/microsoft/vscode-java-test/issues/1014
The  languages.registerCodeLensProvider(documentSelector... ) api is not able to handle the RelativePattern object in the DocumentFilter object. This was breaking the code lens.
It is replaced by String pattern.

