### PR TITLE
bugfix: Do not show test report when there is no test results

### DIFF
--- a/src/runners/runnerScheduler.ts
+++ b/src/runners/runnerScheduler.ts
@@ -149,6 +149,10 @@ class RunnerScheduler {
     }
 
     private showReportIfNeeded(finalResults: ITestResult[]): void {
+        if (finalResults.length === 0) {
+            return;
+        }
+
         const showSetting: string = getShowReportSetting();
         switch (showSetting) {
             case ReportShowSetting.Always:


### PR DESCRIPTION
fix #983 