### PR TITLE
feat: run all tests from active editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "onCommand:java.test.explorer.refresh",
         "onCommand:java.test.explorer.run",
         "onCommand:java.test.explorer.debug",
+        "onCommand:java.test.activeEditor.run",
         "onCommand:java.test.run",
         "onCommand:java.test.debug",
         "onCommand:java.test.cancel",
@@ -195,6 +196,11 @@
                 "command": "java.test.explorer.debugAll",
                 "title": "%contributes.commands.java.test.explorer.debugAll.title%",
                 "icon": "$(debug)",
+                "category": "Java"
+            },
+            {
+                "command": "java.test.activeEditor.run",
+                "title": "%contributes.commands.java.test.activeEditor.run.title%",
                 "category": "Java"
             },
             {

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,7 @@
     "contributes.commands.java.test.explorer.debugAll.title": "Debug All Tests",
     "contributes.commands.java.test.explorer.run.config.title": "Run With Configuration",
     "contributes.commands.java.test.explorer.debug.config.title": "Debug With Configuration",
+    "contributes.commands.java.test.activeEditor.run.title": "Run Tests in Active Editor",
     "contributes.commands.java.test.show.report.title": "Show Test Report",
     "contributes.commands.java.test.relaunch.title": "Relaunch the Tests",
     "contributes.commands.java.test.cancel.title": "Cancel Test Job",

--- a/src/commands/editorCommands.ts
+++ b/src/commands/editorCommands.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'fs';
+import { window } from 'vscode';
+import { logger } from '../logger/logger';
+import { TestKind, TestLevel } from '../protocols';
+import { IRunnerContext } from '../runners/models';
+import { runnerScheduler } from '../runners/runnerScheduler';
+import { searchTestItems } from './explorerCommands';
+
+export async function runTestsInActiveEditor(): Promise<void> {
+    return executeTestsInActiveEditor(false);
+}
+
+async function executeTestsInActiveEditor(isDebug: boolean): Promise<void> {
+    let path: string = '';
+    if (window.activeTextEditor) {
+        path = window.activeTextEditor.document.uri.fsPath;
+    } else {
+        return;
+    }
+    const parts: string[] = path.split('/');
+    const fileName: string = parts[parts.length - 1];
+    const className: string = fileName.split('.')[0];
+    const classFileContent: string = readFileSync(path, 'utf8');
+    const packageLine = classFileContent.match(/^package .*;$/gm);
+    let packageLineParts: string[];
+    let packageName: string;
+    if (packageLine) {
+        packageLineParts = packageLine[0].split(' ');
+        packageName = packageLineParts[1];
+        packageName = packageName.substr(0, packageName.length - 1);
+    } else {
+        return;
+    }
+    const runnerContext: IRunnerContext = {
+        scope: TestLevel.Class,
+        testUri: `file://${path}`,
+        fullName: `${packageName}.${className}`,
+        paramTypes: [],
+        projectName: '',
+        kind: TestKind.None,
+        isDebug,
+        tests: [],
+    };
+    await searchTestItems(runnerContext);
+    if (!runnerContext.tests) {
+        logger.info('Test job is canceled.');
+        return;
+    } else if (runnerContext.tests.length <= 0) {
+        logger.info('No test items found.');
+        return;
+    }
+    return runnerScheduler.run(runnerContext);
+}

--- a/src/commands/editorCommands.ts
+++ b/src/commands/editorCommands.ts
@@ -21,7 +21,7 @@ async function executeTestsInActiveEditor(isDebug: boolean): Promise<void> {
     const fileName: string = parts[parts.length - 1];
     const className: string = fileName.split('.')[0];
     const classFileContent: string = readFileSync(path, 'utf8');
-    const packageLine = classFileContent.match(/^package .*;$/gm);
+    const packageLine: RegExpMatchArray | null  = classFileContent.match(/^package .*;$/gm);
     let packageLineParts: string[];
     let packageName: string;
     if (packageLine) {

--- a/src/commands/explorerCommands.ts
+++ b/src/commands/explorerCommands.ts
@@ -61,7 +61,7 @@ async function executeTestsFromExplorer(isDebug: boolean, node?: ITestItem, laun
     return runnerScheduler.run(runnerContext, launchConfiguration);
 }
 
-async function searchTestItems(runnerContext: IRunnerContext): Promise<void> {
+export async function searchTestItems(runnerContext: IRunnerContext): Promise<void> {
     return new Promise<void>((resolve: () => void, reject: () => void): void => {
         window.withProgress(
             { location: ProgressLocation.Notification, cancellable: true },

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -22,6 +22,7 @@ export namespace JavaTestRunnerCommands {
     export const RUN_TEST_FROM_EXPLORER: string = 'java.test.explorer.run';
     export const DEBUG_ALL_TEST_FROM_EXPLORER: string = 'java.test.explorer.debugAll';
     export const RUN_ALL_TEST_FROM_EXPLORER: string = 'java.test.explorer.runAll';
+    export const RUN_TESTS_FROM_ACTIVE_EDITOR: string = 'java.test.activeEditor.run';
     export const DEBUG_TEST_FROM_EXPLORER: string = 'java.test.explorer.debug';
     export const SHOW_TEST_REPORT: string = 'java.test.show.report';
     export const SHOW_TEST_OUTPUT: string = 'java.test.show.output';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { DebugConfiguration, Event, Extension, ExtensionContext, extensions, Range, Uri, window } from 'vscode';
 import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentOperation, instrumentOperationAsVsCodeCommand } from 'vscode-extension-telemetry-wrapper';
 import { testCodeLensController } from './codelens/TestCodeLensController';
+import { runTestsInActiveEditor } from './commands/editorCommands';
 import { debugTestsFromExplorer, openTextDocument, runTestsFromExplorer } from './commands/explorerCommands';
 import { openLogFile, showOutputChannel } from './commands/logCommands';
 import { runFromCodeLens } from './commands/runFromCodeLens';
@@ -94,6 +95,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.DEBUG_ALL_TEST_FROM_EXPLORER, async () => await debugTestsFromExplorer()),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.RUN_TEST_FROM_EXPLORER, async (node?: ITestItem, launchConfiguration?: DebugConfiguration) => await runTestsFromExplorer(node, launchConfiguration)),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.DEBUG_TEST_FROM_EXPLORER, async (node?: ITestItem, launchConfiguration?: DebugConfiguration) => await debugTestsFromExplorer(node, launchConfiguration)),
+        instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.RUN_TESTS_FROM_ACTIVE_EDITOR, async () => await runTestsInActiveEditor()),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.RELAUNCH_TESTS, async () => await runnerScheduler.relaunch()),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.SHOW_TEST_REPORT, async (tests?: ITestResult[]) => await testReportProvider.report(tests)),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.SHOW_TEST_OUTPUT, () => showOutputChannel()),


### PR DESCRIPTION
Hi!

I managed to create a command that runs all tests from the currently opened file in the active editor, thus addressing the first part of #531.

I'm completely new to VS Code Extension development and almost completely new to JavaScript/TypeScript and I'm pretty sure there's a lot of room for improvement in terms of code style and robustness. So if you folks see any problems with the code I'd be happy to revise the PR according to your guidance :)