### PR TITLE
Improve the perf when resolving code lens in large java file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,10 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "npm: watch",
+            "env": {
+                "DEBUG_VSCODE_JAVA":"true"
+            }
         },
         {
             "type": "java",

--- a/java-extension/com.microsoft.java.test.plugin/META-INF/MANIFEST.MF
+++ b/java-extension/com.microsoft.java.test.plugin/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: com.microsoft.java.test.plugin
 Bundle-SymbolicName: com.microsoft.java.test.plugin;singleton:=true
 Bundle-Version: 0.24.0
 Bundle-Activator: com.microsoft.java.test.plugin.util.JUnitPlugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.jdt.core,
  org.eclipse.jdt.launching,
  org.osgi.framework;version="1.3.0"

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
@@ -20,6 +20,9 @@ import com.microsoft.java.test.plugin.util.TestItemUtils;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.search.IJavaSearchConstants;
 import org.eclipse.jdt.core.search.SearchPattern;
 
@@ -75,6 +78,17 @@ public abstract class BaseFrameworkSearcher implements TestFrameworkSearcher {
     }
 
     @Override
+    public boolean annotates(IAnnotationBinding[] annotations, String annotationName) {
+        for (final IAnnotationBinding annotation : annotations) {
+            final ITypeBinding annotationType = annotation.getAnnotationType();
+            if (annotationType != null && (annotationType.getQualifiedName().equals(annotationName))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public TestItem parseTestItem(IMethod method) throws JavaModelException {
         return TestItemUtils.constructTestItem(method, TestLevel.METHOD, this.getTestKind());
     }
@@ -82,5 +96,11 @@ public abstract class BaseFrameworkSearcher implements TestFrameworkSearcher {
     @Override
     public TestItem parseTestItem(IType type) throws JavaModelException {
         return TestItemUtils.constructTestItem(type, TestLevel.CLASS, this.getTestKind());
+    }
+
+    @Override
+    public TestItem parseTestItem(IMethodBinding methodBinding) throws JavaModelException {
+        return TestItemUtils.constructTestItem((IMethod) methodBinding.getJavaElement(),
+            TestLevel.METHOD, this.getTestKind());
     }
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
@@ -78,11 +78,13 @@ public abstract class BaseFrameworkSearcher implements TestFrameworkSearcher {
     }
 
     @Override
-    public boolean annotates(IAnnotationBinding[] annotations, String annotationName) {
+    public boolean findAnnotation(IAnnotationBinding[] annotations, String[] annotationNames) {
         for (final IAnnotationBinding annotation : annotations) {
             final ITypeBinding annotationType = annotation.getAnnotationType();
-            if (annotationType != null && (annotationType.getQualifiedName().equals(annotationName))) {
-                return true;
+            for (final String annotationName : annotationNames) {
+                if (TestFrameworkUtils.isEquivalentAnnotationType(annotationType, annotationName)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
@@ -75,11 +75,6 @@ public class JUnit4TestSearcher extends BaseFrameworkSearcher {
             return false;
         }
 
-        for (final String annotationName : this.getTestMethodAnnotations()) {
-            if (this.annotates(methodBinding.getAnnotations(), annotationName)) {
-                return true;
-            }
-        }
-        return false;
+        return this.findAnnotation(methodBinding.getAnnotations(), this.getTestMethodAnnotations());
     }
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
@@ -205,7 +205,7 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
             final ITypeBinding annotationType = annotationBinding.getAnnotationType();
             if (annotationType != null && hierarchy.add(annotationType)) {
                 if (matchesName(annotationType, annotationName) ||
-                        matchesNameInAnnotationHierarchy(annotation, annotationName, hierarchy)) {
+                        matchesNameInAnnotationHierarchy(annotationBinding, annotationName, hierarchy)) {
                     return true;
                 }
             }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
@@ -103,12 +103,8 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
         if (methodBinding.isConstructor()) {
             return false;
         }
-        for (final String annotationName : this.getTestMethodAnnotations()) {
-            if (this.annotates(methodBinding.getAnnotations(), annotationName)) {
-                return true;
-            }
-        }
-        return false;
+
+        return this.findAnnotation(methodBinding.getAnnotations(), this.getTestMethodAnnotations());
     }
 
     @SuppressWarnings("rawtypes")
@@ -170,19 +166,21 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
     }
 
     @Override
-    public boolean annotates(IAnnotationBinding[] annotations, String annotationName) {
+    public boolean findAnnotation(IAnnotationBinding[] annotations, String[] annotationNames) {
         for (final IAnnotationBinding annotation : annotations) {
             if (annotation == null) {
                 continue;
             }
-            if (matchesName(annotation.getAnnotationType(), annotationName)) {
-                return true;
-            }
-
-            if (JUPITER_NESTED.equals(annotationName) || JUNIT_PLATFORM_TESTABLE.equals(annotationName)) {
-                final Set<ITypeBinding> hierarchy = new HashSet<>();
-                if (matchesNameInAnnotationHierarchy(annotation, annotationName, hierarchy)) {
+            for (final String annotationName : annotationNames) {
+                if (matchesName(annotation.getAnnotationType(), annotationName)) {
                     return true;
+                }
+    
+                if (JUPITER_NESTED.equals(annotationName) || JUNIT_PLATFORM_TESTABLE.equals(annotationName)) {
+                    final Set<ITypeBinding> hierarchy = new HashSet<>();
+                    if (matchesNameInAnnotationHierarchy(annotation, annotationName, hierarchy)) {
+                        return true;
+                    }
                 }
             }
         }
@@ -190,13 +188,7 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
     }
 
     private boolean matchesName(ITypeBinding annotationType, String annotationName) {
-        if (annotationType != null) {
-            if (annotationType.getQualifiedName().equals(annotationName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return TestFrameworkUtils.isEquivalentAnnotationType(annotationType, annotationName);
     }
 
     private boolean matchesNameInAnnotationHierarchy(IAnnotationBinding annotation, String annotationName,

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestFrameworkSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestFrameworkSearcher.java
@@ -40,7 +40,7 @@ public interface TestFrameworkSearcher {
 
     SearchPattern getSearchPattern();
 
-    boolean annotates(IAnnotationBinding[] annotations, String annotationName);
+    boolean findAnnotation(IAnnotationBinding[] annotations, String[] annotationNames);
 
     @Deprecated
     TestItem parseTestItem(IMethod method) throws JavaModelException;

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestFrameworkSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestFrameworkSearcher.java
@@ -17,13 +17,20 @@ import com.microsoft.java.test.plugin.model.TestKind;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.search.SearchPattern;
 
 public interface TestFrameworkSearcher {
 
     TestKind getTestKind();
 
+    String getJdtTestKind();
+
+    @Deprecated
     boolean isTestMethod(IMethod method);
+
+    boolean isTestMethod(IMethodBinding methodBinding);
 
     boolean isTestClass(IType type);
 
@@ -33,7 +40,12 @@ public interface TestFrameworkSearcher {
 
     SearchPattern getSearchPattern();
 
+    boolean annotates(IAnnotationBinding[] annotations, String annotationName);
+
+    @Deprecated
     TestItem parseTestItem(IMethod method) throws JavaModelException;
+
+    TestItem parseTestItem(IMethodBinding methodBinding) throws JavaModelException;
 
     TestItem parseTestItem(IType type) throws JavaModelException;
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
@@ -17,6 +17,8 @@ import com.microsoft.java.test.plugin.util.TestFrameworkUtils;
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.Modifier;
 
 public class TestNGTestSearcher extends BaseFrameworkSearcher {
 
@@ -29,6 +31,11 @@ public class TestNGTestSearcher extends BaseFrameworkSearcher {
     @Override
     public TestKind getTestKind() {
         return TestKind.TestNG;
+    }
+
+    @Override
+    public String getJdtTestKind() {
+        return "";
     }
 
     @Override
@@ -52,5 +59,23 @@ public class TestNGTestSearcher extends BaseFrameworkSearcher {
             // ignore
             return false;
         }
+    }
+
+    @Override
+    public boolean isTestMethod(IMethodBinding methodBinding) {
+        final int modifiers = methodBinding.getModifiers();
+        if (Modifier.isAbstract(modifiers) || Modifier.isStatic(modifiers)) {
+            return false;
+        }
+
+        if (methodBinding.isConstructor() || !"void".equals(methodBinding.getReturnType().getName())) {
+            return false;
+        }
+        for (final String annotationName : this.getTestMethodAnnotations()) {
+            if (this.annotates(methodBinding.getAnnotations(), annotationName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
@@ -71,11 +71,6 @@ public class TestNGTestSearcher extends BaseFrameworkSearcher {
         if (methodBinding.isConstructor() || !"void".equals(methodBinding.getReturnType().getName())) {
             return false;
         }
-        for (final String annotationName : this.getTestMethodAnnotations()) {
-            if (this.annotates(methodBinding.getAnnotations(), annotationName)) {
-                return true;
-            }
-        }
-        return false;
+        return this.findAnnotation(methodBinding.getAnnotations(), this.getTestMethodAnnotations());
     }
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestFrameworkUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestFrameworkUtils.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -49,7 +49,7 @@ public class TestFrameworkUtils {
     private static final JUnit5TestFinder JUNIT5_TEST_FINDER = new JUnit5TestFinder();
 
     public static void findTestItemsInTypeBinding(ITypeBinding typeBinding, List<TestItem> result,
-            Map<String, TestItem> classMapping) throws JavaModelException {
+            TestItem parentClassTestItem) throws JavaModelException {
         final List<TestFrameworkSearcher> searchers = new ArrayList<>();
         final IType type = (IType) typeBinding.getJavaElement();
         for (final TestFrameworkSearcher searcher : FRAMEWORK_SEARCHERS) {
@@ -95,20 +95,17 @@ public class TestFrameworkUtils {
         }
 
         // set the class item as the child of its declaring type
-        if (classItem != null) {
-            classMapping.put(typeBinding.getQualifiedName(), classItem);
-            final ITypeBinding declarationType = typeBinding.getDeclaringClass();
-            if (declarationType != null) {
-                final TestItem declarationTypeItem = classMapping.get(declarationType.getQualifiedName());
-                if (declarationTypeItem != null) {
-                    declarationTypeItem.addChild(classItem.getId());
-                }
-            }
+        if (classItem != null && parentClassTestItem != null) {
+            parentClassTestItem.addChild(classItem.getId());
         }
 
         for (final ITypeBinding childTypeBinding : typeBinding.getDeclaredTypes()) {
-            findTestItemsInTypeBinding(childTypeBinding, result, classMapping);
+            findTestItemsInTypeBinding(childTypeBinding, result, classItem);
         }
+    }
+
+    public static boolean isEquivalentAnnotationType(ITypeBinding annotationType, String annotationName) {
+        return annotationType != null && Objects.equals(annotationType.getQualifiedName(), annotationName);
     }
 
     public static TestItem resolveTestItemForMethod(IMethod method) throws JavaModelException {

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestFrameworkUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestFrameworkUtils.java
@@ -12,6 +12,8 @@
 package com.microsoft.java.test.plugin.util;
 
 import com.microsoft.java.test.plugin.model.TestItem;
+import com.microsoft.java.test.plugin.model.TestKind;
+import com.microsoft.java.test.plugin.model.TestLevel;
 import com.microsoft.java.test.plugin.searcher.JUnit4TestSearcher;
 import com.microsoft.java.test.plugin.searcher.JUnit5TestSearcher;
 import com.microsoft.java.test.plugin.searcher.TestFrameworkSearcher;
@@ -24,8 +26,17 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.internal.junit.launcher.JUnit4TestFinder;
+import org.eclipse.jdt.internal.junit.launcher.JUnit5TestFinder;
+import org.eclipse.jdt.internal.junit.util.CoreTestSearchEngine;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -34,7 +45,73 @@ public class TestFrameworkUtils {
     public static final TestFrameworkSearcher[] FRAMEWORK_SEARCHERS = new TestFrameworkSearcher[] {
         new JUnit4TestSearcher(), new JUnit5TestSearcher(), new TestNGTestSearcher() };
 
-    public static TestItem resoveTestItemForMethod(IMethod method) throws JavaModelException {
+    private static final JUnit4TestFinder JUNIT4_TEST_FINDER = new JUnit4TestFinder();
+    private static final JUnit5TestFinder JUNIT5_TEST_FINDER = new JUnit5TestFinder();
+
+    public static void findTestItemsInTypeBinding(ITypeBinding typeBinding, List<TestItem> result,
+            Map<String, TestItem> classMapping) throws JavaModelException {
+        final List<TestFrameworkSearcher> searchers = new ArrayList<>();
+        final IType type = (IType) typeBinding.getJavaElement();
+        for (final TestFrameworkSearcher searcher : FRAMEWORK_SEARCHERS) {
+            if (CoreTestSearchEngine.isAccessibleClass(type, searcher.getJdtTestKind())) {
+                searchers.add(searcher);
+            }
+        }
+
+        if (searchers.size() == 0) {
+            return;
+        }
+
+        final List<TestItem> testMethods = new LinkedList<>();
+        final List<String> testMethodIds = new LinkedList<>();
+        for (final IMethodBinding methodBinding : typeBinding.getDeclaredMethods()) {
+            for (final TestFrameworkSearcher searcher : searchers) {
+                if (searcher.isTestMethod(methodBinding)) {
+                    final TestItem methodItem = searcher.parseTestItem(methodBinding);
+                    testMethods.add(methodItem);
+                    testMethodIds.add(methodItem.getId());
+                    break;
+                }
+            }
+        }
+        TestItem classItem = null;
+        if (testMethods.size() > 0) {
+            result.addAll(testMethods);
+            classItem = TestItemUtils.constructTestItem((IType) typeBinding.getJavaElement(),
+                    TestLevel.CLASS);
+            classItem.setChildren(testMethodIds);
+            classItem.setKind(testMethods.get(0).getKind());
+            result.add(classItem);
+        } else {
+            if (JUNIT4_TEST_FINDER.isTest(type)) {
+                // Leverage JUnit4TestFinder to handle @RunWithclasses
+                classItem = TestItemUtils.constructTestItem(type, TestLevel.CLASS, TestKind.JUnit);
+                result.add(classItem);
+            } else if (JUNIT5_TEST_FINDER.isTest(type)) {
+                // Leverage JUnit5TestFinder to handle @Nested and @Testable classes
+                classItem = TestItemUtils.constructTestItem(type, TestLevel.CLASS, TestKind.JUnit5);
+                result.add(classItem);
+            }
+        }
+
+        // set the class item as the child of its declaring type
+        if (classItem != null) {
+            classMapping.put(typeBinding.getQualifiedName(), classItem);
+            final ITypeBinding declarationType = typeBinding.getDeclaringClass();
+            if (declarationType != null) {
+                final TestItem declarationTypeItem = classMapping.get(declarationType.getQualifiedName());
+                if (declarationTypeItem != null) {
+                    declarationTypeItem.addChild(classItem.getId());
+                }
+            }
+        }
+
+        for (final ITypeBinding childTypeBinding : typeBinding.getDeclaredTypes()) {
+            findTestItemsInTypeBinding(childTypeBinding, result, classMapping);
+        }
+    }
+
+    public static TestItem resolveTestItemForMethod(IMethod method) throws JavaModelException {
         for (final TestFrameworkSearcher searcher : FRAMEWORK_SEARCHERS) {
             if (searcher.isTestMethod(method)) {
                 return searcher.parseTestItem(method);
@@ -59,6 +136,7 @@ public class TestFrameworkUtils {
      * @param annotationToSearch The annotation string.
      * @param checkHierarchy Specify whether to search the whole annotation hierarchy.
      */
+    @Deprecated
     public static Optional<IAnnotation> getAnnotation(IMember member, String annotationToSearch,
             boolean checkHierarchy) {
         if (!IAnnotatable.class.isInstance(member)) {
@@ -110,6 +188,7 @@ public class TestFrameworkUtils {
      * @param annotationToSearch The annotation string.
      * @param checkHierarchy Specify whether to search the whole annotation hierarchy.
      */
+    @Deprecated
     public static boolean hasAnnotation(IMember member, String annotationToSearch, boolean checkHierarchy) {
         return getAnnotation(member, annotationToSearch, checkHierarchy).isPresent();
     }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -98,6 +98,7 @@ public class TestSearchUtils {
         parser.setSource(unit);
         parser.setFocalPosition(0);
         parser.setResolveBindings(true);
+        parser.setIgnoreMethodBodies(true);
         final CompilationUnit root = (CompilationUnit) parser.createAST(monitor);
         final ASTNode node = root.findDeclaringNode(primaryType.getKey());
         if (!(node instanceof TypeDeclaration)) {
@@ -109,8 +110,7 @@ public class TestSearchUtils {
             return resultList;
         }
 
-        final Map<String, TestItem> classMapping = new HashMap<>();
-        TestFrameworkUtils.findTestItemsInTypeBinding(binding, resultList, classMapping);
+        TestFrameworkUtils.findTestItemsInTypeBinding(binding, resultList, null /*parentClassItem*/);
 
         return resultList;
     }

--- a/java-extension/com.microsoft.java.test.plugin/target.target
+++ b/java-extension/com.microsoft.java.test.plugin/target.target
@@ -10,7 +10,7 @@
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-            <repository location="http://download.eclipse.org/releases/2019-06/"/>
+            <repository location="http://download.eclipse.org/releases/2020-06/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>

--- a/java-extension/pom.xml
+++ b/java-extension/pom.xml
@@ -53,9 +53,9 @@
     </build>
     <repositories>
         <repository>
-            <id>202003</id>
+            <id>202006</id>
             <layout>p2</layout>
-            <url>https://download.eclipse.org/releases/2020-03/</url>
+            <url>https://download.eclipse.org/releases/2020-06/</url>
         </repository>
         <repository>
             <id>oss.sonatype.org</id>

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,7 +343,7 @@
         },
         "acorn": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+            "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
             "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         },
         "acorn-globals": {
@@ -422,7 +422,7 @@
         },
         "ansi-colors": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
@@ -631,7 +631,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -845,7 +845,7 @@
                 },
                 "util": {
                     "version": "0.10.3",
-                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
                     "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
                     "dev": true,
                     "requires": {
@@ -1587,7 +1587,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -1758,7 +1758,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -1808,7 +1808,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -2460,7 +2460,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -3238,7 +3238,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -3296,7 +3296,7 @@
             "dependencies": {
                 "combined-stream": {
                     "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+                    "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
                     "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                     "dev": true,
                     "requires": {
@@ -4117,7 +4117,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -5121,7 +5121,7 @@
         },
         "json5": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
             "dev": true
         },
@@ -5212,7 +5212,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -5572,7 +5572,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -5587,7 +5587,7 @@
                 },
                 "string_decoder": {
                     "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
@@ -6558,7 +6558,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -6596,7 +6596,7 @@
         },
         "os-locale": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
@@ -7308,7 +7308,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -8478,7 +8478,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -8807,7 +8807,7 @@
                 },
                 "yargs": {
                     "version": "3.10.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                    "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                     "requires": {
                         "camelcase": "^1.0.2",
@@ -9104,7 +9104,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -9748,7 +9748,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {

--- a/test/gradle-junit5-suite/codelens.test.ts
+++ b/test/gradle-junit5-suite/codelens.test.ts
@@ -84,6 +84,15 @@ suite('Code Lens Tests', function() {
         assert.ok(failedDetail!.duration !== undefined, 'Should have execution time');
     });
 
+    test("Can show Code Lens for methods annotated with meta-annotation", async function() {
+        const document: TextDocument = await workspace.openTextDocument(Uris.GRADLE_JUNIT5_META_ANNOTATION_TEST);
+        await window.showTextDocument(document);
+
+        const codeLensProvider: TestCodeLensProvider = new TestCodeLensProvider();
+        let codeLens: CodeLens[] = await codeLensProvider.provideCodeLenses(document, Token.cancellationToken);
+        assert.equal(codeLens.length, 4);
+    });
+
     test("Can run test method annotated with @Nested", async function() {
         const document: TextDocument = await workspace.openTextDocument(Uris.GRADLE_JUNIT5_NESTED_TEST);
         await window.showTextDocument(document);

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -39,6 +39,7 @@ export namespace Uris {
     const GRADLE_JUNIT5_TEST_PACKAGE: string = path.join('junit5', 'src', 'test', 'java', 'junit5');
     export const GRADLE_JUNIT5_PARAMETERIZED_TEST: Uri = Uri.file(path.join(TEST_PROJECT_BASE_PATH, GRADLE_JUNIT5_TEST_PACKAGE, 'ParameterizedAnnotationTest.java'));
     export const GRADLE_JUNIT5_NESTED_TEST: Uri = Uri.file(path.join(TEST_PROJECT_BASE_PATH, GRADLE_JUNIT5_TEST_PACKAGE, 'NestedTest.java'));
+    export const GRADLE_JUNIT5_META_ANNOTATION_TEST: Uri = Uri.file(path.join(TEST_PROJECT_BASE_PATH, GRADLE_JUNIT5_TEST_PACKAGE, 'MetaAnnotationTest.java'));
     export const GRADLE_JUNIT5_PROPERTY_TEST: Uri = Uri.file(path.join(TEST_PROJECT_BASE_PATH, GRADLE_JUNIT5_TEST_PACKAGE, 'PropertyTest.java'));
     export const GRADLE_CUCUMBER_TEST: Uri = Uri.file(path.join(TEST_PROJECT_BASE_PATH, GRADLE_JUNIT5_TEST_PACKAGE, 'cucumber', 'CucumberTest.java'));
     export const GRADLE_CUCUMBER_STEP: Uri = Uri.file(path.join(TEST_PROJECT_BASE_PATH, GRADLE_JUNIT5_TEST_PACKAGE, 'cucumber', 'CucumberSteps.java'));

--- a/test/test-projects/junit5/src/test/java/junit5/FastTest.java
+++ b/test/test-projects/junit5/src/test/java/junit5/FastTest.java
@@ -1,0 +1,16 @@
+package junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("fast")
+@Test
+public @interface FastTest {
+}

--- a/test/test-projects/junit5/src/test/java/junit5/MetaAnnotationTest.java
+++ b/test/test-projects/junit5/src/test/java/junit5/MetaAnnotationTest.java
@@ -1,0 +1,7 @@
+package junit5;
+
+public class MetaAnnotationTest {
+    @FastTest
+    void myFastTest() {
+    }
+}


### PR DESCRIPTION
fix #1039 

Using the attached source file in #1039, below are some data points with this PR change:

### On Xeon E5-1620 v4 @3.50GHz + 32G mem + Windows
#### Open workspace (ms)
| | 1 | 2 | 3 | 4 | 5 | AVG |
|---|---|---|---|---|---|---|
| New | 1432 | 2262 | 1036 | 2186 | 1214 | 1626 |
| Old | 8257 | 8380 | 13953 | 8678 | 10782 | 10010 |

#### Document Change - Input `Enter` (ms)
| | 1 | 2 | 3 | 4 | 5 | AVG |
|---|---|---|---|---|---|---|
| New | 380 | 284 | 278 | 258 | 274 | 295 |
| Old | 2963 | 3383 | 3122 | 2659 | 2635 | 2952 |

### On i5 @ 2.9GHz + 8G mem + MacOS
#### Open workspace (ms)
| | 1 | 2 | 3 | 4 | 5 | AVG |
|---|---|---|---|---|---|---|
| New | 2110 | 3438 | 1966 | 2387 | 2375 | 2455 |
| Old | 10714 | 8551 | 9146 | 9828 | 11441 | 9936 |

#### Document Change - Input `Enter` (ms)
| | 1 | 2 | 3 | 4 | 5 | AVG |
|---|---|---|---|---|---|---|
| New | 1760 | 395 | 345 | 436 | 405 | 668 |
| Old | 4597 | 4041 | 3863 | 3586 | 3584 | 3934 |

### Follow-ups

Besides this PR change, we can improve the perf further, including:

- Stop resolving the @DisplayName at compile time. This should be resolved at runtime actually
- Stop resolving the parameters for JUnit 5 cases, only resolve them when necessary at launching
- Skip some searchers according to the project's test dependencies
- Use text match