### PR TITLE
refactor: Lazy load the parameter types

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/TestItem.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/TestItem.java
@@ -32,18 +32,15 @@ public class TestItem {
 
     private String project;
 
-    private List<String> paramTypes;
-
     private Location location;
 
-    public TestItem(String displayName, String fullName, String uri, String project, List<String> paramTypes,
+    public TestItem(String displayName, String fullName, String uri, String project,
             Range range, TestLevel level, TestKind kind) {
         this.displayName = displayName;
         this.fullName = fullName;
         this.level = level;
         this.kind = kind;
         this.project = project;
-        this.paramTypes = paramTypes;
         this.location = new Location(uri, range);
         this.id = String.format("%s@%s", project, fullName);
     }
@@ -109,14 +106,6 @@ public class TestItem {
             this.children = new ArrayList<>();
         }
         this.children.add(child);
-    }
-
-    public List<String> getParamTypes() {
-        return paramTypes;
-    }
-
-    public void setParamTypes(List<String> paramTypes) {
-        this.paramTypes = paramTypes;
     }
 
     public Location getLocation() {

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
@@ -15,27 +15,17 @@ import com.microsoft.java.test.plugin.model.TestItem;
 import com.microsoft.java.test.plugin.model.TestKind;
 import com.microsoft.java.test.plugin.util.TestFrameworkUtils;
 
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
-import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
-import org.eclipse.jdt.core.dom.NodeFinder;
-import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
-import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
 
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -118,22 +108,6 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
             item.setDisplayName((String) annotation.get().getMemberValuePairs()[0].getValue());
         }
 
-        // Get the parameter type information
-        final List<String> result = new LinkedList<>();
-        final CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(
-                method.getDeclaringType().getCompilationUnit(), CoreASTProvider.WAIT_YES, new NullProgressMonitor());
-        final ISourceRange sourceRange = method.getSourceRange();
-        final ASTNode name = NodeFinder.perform(astRoot, sourceRange.getOffset(), sourceRange.getLength(),
-                method.getCompilationUnit());
-        if (name instanceof MethodDeclaration) {
-            final List parameterList = ((MethodDeclaration) name).parameters();
-            for (final Object obj : parameterList) {
-                if (obj instanceof SingleVariableDeclaration) {
-                    result.add(((SingleVariableDeclaration) obj).getType().resolveBinding().getQualifiedName());
-                }
-            }
-        }
-        item.setParamTypes(result);
         return item;
     }
 
@@ -150,16 +124,6 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
                 item.setDisplayName((String) annotation.getAllMemberValuePairs()[0].getValue());
                 break;
             }
-        }
-
-        // parse the parameters
-        final ITypeBinding[] parameters = methodBinding.getParameterTypes();
-        if (parameters.length > 0) {
-            final List<String> result = new LinkedList<>();
-            for (final ITypeBinding parameter : parameters) {
-                result.add(parameter.getQualifiedName());
-            }
-            item.setParamTypes(result);
         }
 
         return item;

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
@@ -25,8 +25,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.lsp4j.Range;
 
-import java.util.Collections;
-
 @SuppressWarnings("restriction")
 public class TestItemUtils {
 
@@ -51,11 +49,13 @@ public class TestItemUtils {
         final Range range = parseTestItemRange(element);
         final String projectName = element.getJavaProject().getProject().getName();
 
-        return new TestItem(displayName, fullName, uri, projectName, Collections.emptyList(), range, level, kind);
+        return new TestItem(displayName, fullName, uri, projectName, range, level, kind);
     }
 
     public static Range parseTestItemRange(IJavaElement element) throws JavaModelException {
         if (element instanceof ISourceReference) {
+            // getSourceRange() is not used here because we want the Code Lens appear above the
+            // method name, not above the annotation.
             final ISourceRange range = ((ISourceReference) element).getNameRange();
             return JDTUtils.toRange(element.getOpenable(), range.getOffset(), range.getLength());
         }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -94,12 +94,7 @@ public class TestSearchUtils {
             return resultList;
         }
 
-        final ASTParser parser = ASTParser.newParser(AST.JLS14);
-        parser.setSource(unit);
-        parser.setFocalPosition(0);
-        parser.setResolveBindings(true);
-        parser.setIgnoreMethodBodies(true);
-        final CompilationUnit root = (CompilationUnit) parser.createAST(monitor);
+        final CompilationUnit root = (CompilationUnit) parseToAst(unit, monitor);
         final ASTNode node = root.findDeclaringNode(primaryType.getKey());
         if (!(node instanceof TypeDeclaration)) {
             return resultList;
@@ -113,6 +108,15 @@ public class TestSearchUtils {
         TestFrameworkUtils.findTestItemsInTypeBinding(binding, resultList, null /*parentClassItem*/);
 
         return resultList;
+    }
+
+    public static ASTNode parseToAst(final ICompilationUnit unit, IProgressMonitor monitor) {
+        final ASTParser parser = ASTParser.newParser(AST.JLS14);
+        parser.setSource(unit);
+        parser.setFocalPosition(0);
+        parser.setResolveBindings(true);
+        parser.setIgnoreMethodBodies(true);
+        return parser.createAST(monitor);
     }
 
     /**

--- a/src/commands/explorerCommands.ts
+++ b/src/commands/explorerCommands.ts
@@ -26,7 +26,6 @@ async function executeTestsFromExplorer(isDebug: boolean, node?: ITestItem, laun
         scope: TestLevel.Root,
         testUri: '',
         fullName: '',
-        paramTypes: [],
         projectName: '',
         kind: TestKind.None,
         isDebug,
@@ -40,7 +39,6 @@ async function executeTestsFromExplorer(isDebug: boolean, node?: ITestItem, laun
             runnerContext.fullName = node.fullName;
         }
         if (node.level === TestLevel.Method) {
-            runnerContext.paramTypes = node.paramTypes;
             runnerContext.tests = [node];
         }
     }

--- a/src/commands/runFromCodeLens.ts
+++ b/src/commands/runFromCodeLens.ts
@@ -10,7 +10,6 @@ export async function runFromCodeLens(test: ITestItem, isDebug: boolean): Promis
         scope: test.level,
         testUri: test.location.uri,
         fullName: test.fullName,
-        paramTypes: test.paramTypes,
         kind: test.kind,
         projectName: test.project,
         tests: [test],

--- a/src/explorer/testExplorer.ts
+++ b/src/explorer/testExplorer.ts
@@ -64,7 +64,6 @@ export class TestExplorer implements TreeDataProvider<ITestItem>, Disposable {
                     kind: TestKind.None,
                     project: '',
                     level: TestLevel.Folder,
-                    paramTypes: [],
                     location: {
                         uri: '',
                         range: new Range(0, 0, 0, 0),
@@ -104,7 +103,6 @@ export class TestExplorer implements TreeDataProvider<ITestItem>, Disposable {
                     kind: TestKind.None,
                     project: '',
                     level: TestLevel.Folder,
-                    paramTypes: [],
                     location: {
                         uri: folder.uri.toString(),
                         range: new Range(0, 0, 0, 0),

--- a/src/protocols.ts
+++ b/src/protocols.ts
@@ -16,7 +16,6 @@ export interface ITestItem {
     kind: TestKind;
     project: string;
     level: TestLevel;
-    paramTypes: string[];
     location: ILocation;
 }
 

--- a/src/runners/models.ts
+++ b/src/runners/models.ts
@@ -34,7 +34,6 @@ export interface IRunnerContext {
     scope: TestLevel;
     testUri: string;
     fullName: string;
-    paramTypes: string[];
     projectName: string;
     isDebug: boolean;
     kind: TestKind;

--- a/src/utils/commandUtils.ts
+++ b/src/utils/commandUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { commands } from 'vscode';
+import { commands, Position } from 'vscode';
 import { JavaLanguageServerCommands, JavaTestRunnerDelegateCommands } from '../constants/commands';
 import { logger } from '../logger/logger';
 import { ILocation, ISearchTestItemParams, ITestItem, TestKind, TestLevel } from '../protocols';
@@ -32,7 +32,8 @@ export async function searchTestLocation(fullName: string): Promise<ILocation[]>
         JavaTestRunnerDelegateCommands.SEARCH_TEST_LOCATION, fullName) || [];
 }
 
-export async function resolveJUnitLaunchArguments(uri: string, classFullName: string, testName: string, project: string, scope: TestLevel, testKind: TestKind): Promise<IJUnitLaunchArguments> {
+export async function resolveJUnitLaunchArguments(uri: string, classFullName: string, testName: string, project: string,
+                                                  scope: TestLevel, testKind: TestKind, start?: Position, end?: Position): Promise<IJUnitLaunchArguments> {
     const argument: IJUnitLaunchArguments | undefined = await executeJavaLanguageServerCommand<IJUnitLaunchArguments>(
         JavaTestRunnerDelegateCommands.RESOLVE_JUNIT_ARGUMENT, JSON.stringify({
             uri,
@@ -41,6 +42,8 @@ export async function resolveJUnitLaunchArguments(uri: string, classFullName: st
             project,
             scope,
             testKind,
+            start,
+            end,
         }));
 
     if (!argument) {

--- a/src/utils/launchUtils.ts
+++ b/src/utils/launchUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { DebugConfiguration } from 'vscode';
+import { DebugConfiguration, Position } from 'vscode';
 import { TestKind, TestLevel } from '../protocols';
 import { IExecutionConfig } from '../runConfigs';
 import { BaseRunner } from '../runners/baseRunner/BaseRunner';
@@ -89,12 +89,16 @@ async function getJUnitLaunchArguments(runnerContext: IRunnerContext): Promise<I
     className = nameArray[0];
     if (nameArray.length > 1) {
         methodName = nameArray[1];
-        if (runnerContext.paramTypes.length > 0) {
-            methodName = `${methodName}(${runnerContext.paramTypes.join(',')})`;
-        }
     }
 
-    return await resolveJUnitLaunchArguments(runnerContext.testUri, className, methodName, runnerContext.projectName, runnerContext.scope, runnerContext.kind);
+    let start: Position | undefined;
+    let end: Position | undefined;
+    if (runnerContext.kind === TestKind.JUnit5 && runnerContext.scope === TestLevel.Method) {
+        start = runnerContext.tests[0].location.range.start;
+        end = runnerContext.tests[0].location.range.end;
+    }
+
+    return await resolveJUnitLaunchArguments(runnerContext.testUri, className, methodName, runnerContext.projectName, runnerContext.scope, runnerContext.kind, start, end);
 }
 
 async function getTestNGLaunchArguments(projectName: string): Promise<IJUnitLaunchArguments> {

--- a/test/gradle-junit5-suite/codelens.test.ts
+++ b/test/gradle-junit5-suite/codelens.test.ts
@@ -27,8 +27,6 @@ suite('Code Lens Tests', function() {
 
         const testItem: ITestItem[] = command!.arguments as ITestItem[];
         assert.equal(testItem.length, 1);
-        assert.equal(testItem[0].paramTypes[0], 'java.lang.String');
-        assert.equal(testItem[0].paramTypes[1], 'java.lang.Boolean');
 
         await commands.executeCommand(command!.command, testItem[0]);
 
@@ -73,7 +71,6 @@ suite('Code Lens Tests', function() {
 
         const testItem: ITestItem[] = command!.arguments as ITestItem[];
         assert.equal(testItem.length, 1);
-        assert.equal(testItem[0].paramTypes[0], 'int');
 
         await commands.executeCommand(command!.command, testItem[0]);
 


### PR DESCRIPTION
Only resolve the method parameter types when needed. Before this change, we will always parse the method parameters when it's a JUnit 5's case. But that's not necessary because this information is only needed when the user wants to launch at method level.