### PR TITLE
Get ASTNode from ASTProvider

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -41,6 +41,7 @@ import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.core.search.IJavaSearchConstants;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
@@ -111,12 +112,16 @@ public class TestSearchUtils {
     }
 
     public static ASTNode parseToAst(final ICompilationUnit unit, IProgressMonitor monitor) {
-        final ASTParser parser = ASTParser.newParser(AST.JLS14);
-        parser.setSource(unit);
-        parser.setFocalPosition(0);
-        parser.setResolveBindings(true);
-        parser.setIgnoreMethodBodies(true);
-        return parser.createAST(monitor);
+        final CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, monitor);
+        if (astRoot == null) {
+            final ASTParser parser = ASTParser.newParser(AST.JLS14);
+            parser.setSource(unit);
+            parser.setFocalPosition(0);
+            parser.setResolveBindings(true);
+            parser.setIgnoreMethodBodies(true);
+            return parser.createAST(monitor);
+        }
+        return astRoot;
     }
 
     /**

--- a/test/test-projects/modular-gradle/build.gradle
+++ b/test/test-projects/modular-gradle/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation('org.junit.jupiter:junit-jupiter:5.5.2')
+    testImplementation('org.junit.jupiter:junit-jupiter:5.6.0')
 }
 
 test {


### PR DESCRIPTION
Did some profiling to check the improvement. Given a 5000+ lines test file, doing the following operations:
- 5 times of code completion (keep enter `.` and `backspace`)
- write `String a = "";`
- write `String b = a;`
- insert code snippet `systrace`.

### Before
![WeChat Screenshot_20200831144332](https://user-images.githubusercontent.com/6193897/91691959-287d9b00-eb9b-11ea-87c4-e2719294b3bf.png)

### After
![WeChat Screenshot_20200831143822](https://user-images.githubusercontent.com/6193897/91691975-303d3f80-eb9b-11ea-8696-e6bad9614d13.png)

