### PR TITLE
bugfix: Cannot run parameterized test if the parameter has generic types

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
@@ -35,6 +35,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
@@ -150,8 +151,12 @@ public class JUnitLaunchUtils {
             final List<String> parameters = new LinkedList<>();
             for (final Object obj : ((MethodDeclaration) methodDeclaration).parameters()) {
                 if (obj instanceof SingleVariableDeclaration) {
-                    parameters.add(((SingleVariableDeclaration) obj).getType()
-                        .resolveBinding().getQualifiedName());
+                    final ITypeBinding paramTypeBinding = ((SingleVariableDeclaration) obj).getType().resolveBinding();
+                    if (paramTypeBinding.isParameterizedType()) {
+                        parameters.add(paramTypeBinding.getBinaryName());
+                    } else {
+                        parameters.add(paramTypeBinding.getQualifiedName());
+                    }
                 }
             }
             if (parameters.size() > 0) {

--- a/test/gradle-junit5-suite/codelens.test.ts
+++ b/test/gradle-junit5-suite/codelens.test.ts
@@ -19,7 +19,7 @@ suite('Code Lens Tests', function() {
 
         const codeLensProvider: TestCodeLensProvider = new TestCodeLensProvider();
         const codeLens: CodeLens[] = await codeLensProvider.provideCodeLenses(document, Token.cancellationToken);
-        assert.equal(codeLens.length, 6, 'Code Lens should appear for @ParameterizedTest annotation');
+        assert.equal(codeLens.length, 8, 'Code Lens should appear for @ParameterizedTest annotation');
 
         const command: Command | undefined = codeLens[0].command;
         assert.notEqual(command, undefined, 'Command inside Code Lens should not be undefined');
@@ -44,7 +44,7 @@ suite('Code Lens Tests', function() {
         const codeLensProvider: TestCodeLensProvider = new TestCodeLensProvider();
         const codeLens: CodeLens[] = await codeLensProvider.provideCodeLenses(document, Token.cancellationToken);
 
-        const command: Command | undefined = codeLens[2].command;
+        const command: Command | undefined = codeLens[4].command;
 
         const testItem: ITestItem[] = command!.arguments as ITestItem[];
 
@@ -55,6 +55,25 @@ suite('Code Lens Tests', function() {
         const failedDetail: ITestResult| undefined = testResultManager.getResultById(`${projectName}@junit5.ParameterizedAnnotationTest#equal`);
         assert.equal(failedDetail!.status, TestStatus.Fail);
         assert.ok(failedDetail!.trace !== undefined, 'Should have error trace');
+    });
+
+    test("Can run test with generic typed parameter", async function() {
+        const document: TextDocument = await workspace.openTextDocument(Uris.GRADLE_JUNIT5_PARAMETERIZED_TEST);
+        await window.showTextDocument(document);
+
+        const codeLensProvider: TestCodeLensProvider = new TestCodeLensProvider();
+        const codeLens: CodeLens[] = await codeLensProvider.provideCodeLenses(document, Token.cancellationToken);
+
+        const command: Command | undefined = codeLens[2].command;
+
+        const testItem: ITestItem[] = command!.arguments as ITestItem[];
+
+        await commands.executeCommand(command!.command, testItem[0]);
+
+        const projectName: string = testItem[0].project;
+
+        const detail: ITestResult| undefined = testResultManager.getResultById(`${projectName}@junit5.ParameterizedAnnotationTest#canRunWithGenericTypedParameter`);
+        assert.equal(detail!.status, TestStatus.Pass);
     });
 
     test("Can run test method annotated with @Testable", async function() {

--- a/test/test-projects/junit5/src/test/java/junit5/ParameterizedAnnotationTest.java
+++ b/test/test-projects/junit5/src/test/java/junit5/ParameterizedAnnotationTest.java
@@ -2,8 +2,13 @@ package junit5;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ParameterizedAnnotationTest {
 
@@ -25,5 +30,14 @@ public class ParameterizedAnnotationTest {
     })
     public void equal(int first, int second) throws Exception {
         assertEquals(first, second);
+    }
+
+    @ParameterizedTest(name = "Test {0} is a Palindrome")
+    @MethodSource("palindromeProvider")
+    void canRunWithGenericTypedParameter(List<Integer> argument) {
+    }
+
+    static Stream<List<Integer>> palindromeProvider() {
+        return Stream.of(Collections.singletonList(1), Collections.singletonList(1));
     }
 }


### PR DESCRIPTION
fix #1053 