### PR TITLE
chore: Set bundle required environment to JavaSE-1.8

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/META-INF/MANIFEST.MF
+++ b/java-extension/com.microsoft.java.test.plugin/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: com.microsoft.java.test.plugin
 Bundle-SymbolicName: com.microsoft.java.test.plugin;singleton:=true
 Bundle-Version: 0.24.2
 Bundle-Activator: com.microsoft.java.test.plugin.util.JUnitPlugin
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.jdt.core,
  org.eclipse.jdt.launching,
  org.osgi.framework;version="1.3.0"


### PR DESCRIPTION
fix #1048 