### PR TITLE
Use vmArgs in test configuration setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,12 +300,12 @@
                             "description": "%configuration.java.test.config.workingDirectory.description%",
                             "default": "${workspaceFolder}"
                         },
-                        "vmargs": {
+                        "vmArgs": {
                             "type": "array",
                             "items": {
                                 "type": "string"
                             },
-                            "description": "%configuration.java.test.config.vmargs.description%",
+                            "description": "%configuration.java.test.config.vmArgs.description%",
                             "default": []
                         },
                         "args": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -24,7 +24,7 @@
     "configuration.java.test.config.item.description": "Specify the configuration item for running the tests",
     "configuration.java.test.config.name.description": "Specify the name of the configuration item",
     "configuration.java.test.config.workingDirectory.description": "Specify the working directory when running the tests",
-    "configuration.java.test.config.vmargs.description": "Specify the extra options and system properties for the JVM",
+    "configuration.java.test.config.vmArgs.description": "Specify the extra options and system properties for the JVM",
     "configuration.java.test.config.args.description": "Specify the command line arguments which will be passed to the test runner",
     "configuration.java.test.config.env.description": "Specify the extra environment variables when running the tests",
     "configuration.java.test.config.sourcePaths.description": "Specify extra source paths when debugging the tests"

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -24,7 +24,7 @@
     "configuration.java.test.config.item.description": "设定运行测试时所用的配置项",
     "configuration.java.test.config.name.description": "命名配置项",
     "configuration.java.test.config.workingDirectory.description": "设定执行测试时的工作目录",
-    "configuration.java.test.config.vmargs.description": "设定启动 JVM 的额外选项和系统属性",
+    "configuration.java.test.config.vmArgs.description": "设定启动 JVM 的额外选项和系统属性",
     "configuration.java.test.config.args.description": "设定启动 Test Runner 时的命令行参数",
     "configuration.java.test.config.env.description": "启动应用程序时自定义的环境变量",
     "configuration.java.test.config.sourcePaths.description": "设定调试测试用例时的源代码路径"

--- a/src/runConfigs.ts
+++ b/src/runConfigs.ts
@@ -7,7 +7,9 @@ export interface IExecutionConfig {
     name?: string;
     workingDirectory?: string;
     args?: any[];
+    // deprecated, we should align with the debug launch configuration, which is 'vmArgs'
     vmargs?: any[];
+    vmArgs?: any[];
     env?: { [key: string]: string; };
     sourcePaths?: string[];
 }

--- a/src/utils/launchUtils.ts
+++ b/src/utils/launchUtils.ts
@@ -19,7 +19,9 @@ export async function resolveLaunchConfigurationForRunner(runner: BaseRunner, ru
             env = config.env;
         }
 
-        if (config && config.vmargs) {
+        if (config && config.vmArgs) {
+            testNGArguments.vmArguments.push(...config.vmArgs.filter(Boolean));
+        } else if (config && config.vmargs) {
             testNGArguments.vmArguments.push(...config.vmargs.filter(Boolean));
         }
 
@@ -51,7 +53,9 @@ export async function resolveLaunchConfigurationForRunner(runner: BaseRunner, ru
 export async function getDebugConfigurationForEclipseRunner(runnerContext: IRunnerContext, config?: IExecutionConfig): Promise<DebugConfiguration> {
     const junitLaunchArgs: IJUnitLaunchArguments = await getJUnitLaunchArguments(runnerContext);
 
-    if (config && config.vmargs) {
+    if (config && config.vmArgs) {
+        junitLaunchArgs.vmArguments.push(...config.vmArgs.filter(Boolean));
+    } else if (config && config.vmargs) {
         junitLaunchArgs.vmArguments.push(...config.vmargs.filter(Boolean));
     }
     let env: {} = {};


### PR DESCRIPTION
Address #852 

Use `vmArgs` to align with the debug launch configuration.

The `vmargs` is deprecated