### PR TITLE
feat: Add shortcut buttons in editor toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,18 @@
             }
         ],
         "menus": {
+            "editor/title": [
+                {
+                    "command": "java.test.editor.run",
+                    "when": "resourcePath =~ /.*[\\\\/]src[\\\\/]test[\\\\/]java[\\\\/].*[Tt]ests?\\.java/",
+                    "group": "1_run@10"
+                },
+                {
+                    "command": "java.test.editor.debug",
+                    "when": "resourcePath =~ /.*[\\\\/]src[\\\\/]test[\\\\/]java[\\\\/].*[Tt]ests?\\.java/",
+                    "group": "1_run@20"
+                }
+            ],
             "view/title": [
                 {
                     "command": "java.test.relaunch",
@@ -216,11 +228,13 @@
             {
                 "command": "java.test.editor.run",
                 "title": "%contributes.commands.java.test.editor.run.title%",
+                "icon": "$(play)",
                 "category": "Java"
             },
             {
                 "command": "java.test.editor.debug",
                 "title": "%contributes.commands.java.test.editor.debug.title%",
+                "icon": "$(debug-alt-small)",
                 "category": "Java"
             },
             {


### PR DESCRIPTION
Show the `run test` button in editor toolbar if the java file locates in `src/test/java` and ends with `T(t)est(s)`