### PR TITLE
fix: Use java:serverMode to determine the visibility of the explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,7 @@
         "Other"
     ],
     "activationEvents": [
-        "onLanguage:java",
-        "workspaceContains:pom.xml",
-        "workspaceContains:build.gradle",
-        "workspaceContains:.classpath",
+        "onView:testExplorer",
         "onCommand:java.test.editor.run",
         "onCommand:java.test.editor.debug",
         "onCommand:java.test.cancel",
@@ -64,7 +61,7 @@
                 {
                     "id": "testExplorer",
                     "name": "Java",
-                    "when": "java:testRunnerActivated"
+                    "when": "java:serverMode"
                 }
             ]
         },

--- a/src/constants/configs.ts
+++ b/src/constants/configs.ts
@@ -25,8 +25,6 @@ export const HINT_FOR_DEPRECATED_CONFIG_SETTING_KEY: string = 'java.test.message
 export const CONFIG_DOCUMENT_URL: string = 'https://aka.ms/java-test-config';
 export const HINT_FOR_DEFAULT_CONFIG_SETTING_KEY: string = 'java.test.message.hintForSetingDefaultConfig';
 
-export const ACTIVATION_CONTEXT_KEY: string = 'java:testRunnerActivated';
-
 export enum ReportShowSetting {
     Always = 'always',
     OnFail = 'onFailure',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,6 @@ import { runFromCodeLens } from './commands/runFromCodeLens';
 import { executeTestsFromUri } from './commands/runFromUri';
 import { openStackTrace, openTestSourceLocation } from './commands/testReportCommands';
 import { JavaTestRunnerCommands } from './constants/commands';
-import { ACTIVATION_CONTEXT_KEY } from './constants/configs';
 import { testExplorer } from './explorer/testExplorer';
 import { logger } from './logger/logger';
 import { ITestItem } from './protocols';
@@ -30,7 +29,6 @@ import { migrateTestConfig } from './utils/configUtils';
 export async function activate(context: ExtensionContext): Promise<void> {
     await initializeFromJsonFile(context.asAbsolutePath('./package.json'), { firstParty: true });
     await instrumentOperation('activation', doActivate)(context);
-    await commands.executeCommand('setContext', ACTIVATION_CONTEXT_KEY, true);
 }
 
 export async function deactivate(): Promise<void> {


### PR DESCRIPTION
This is better than creating a new context key