### PR TITLE
feat: Support running tests from Java Project explorer

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
@@ -11,24 +11,47 @@
 
 package com.microsoft.java.test.plugin.launchers;
 
+import com.microsoft.java.test.plugin.util.TestSearchUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.Launch;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.junit.JUnitMessages;
+import org.eclipse.jdt.internal.junit.Messages;
+import org.eclipse.jdt.internal.junit.launcher.ITestKind;
+import org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants;
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.VMRunnerConfiguration;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.launcher.JUnitLaunchConfigurationDelegate {
+
+    private boolean fIsHierarchicalPackage;
+
     public JUnitLaunchArguments getJUnitLaunchArguments(ILaunchConfiguration configuration, String mode,
-            IProgressMonitor monitor) throws CoreException {
+            boolean isHierarchicalPackage, IProgressMonitor monitor) throws CoreException {
+        fIsHierarchicalPackage = isHierarchicalPackage;
         final ILaunch launch = new Launch(configuration, mode, null);
 
         // TODO: Make the getVMRunnerConfiguration() in super class protected.
@@ -48,11 +71,85 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
             launchArguments.modulepath = config.getModulepath();
             launchArguments.vmArguments = getVmArguments(config);
             launchArguments.programArguments = config.getProgramArguments();
+
+            // The JUnit 5 launcher only supports run a single package, here we add all the sub-package names
+            // to the package name file as a workaround
+            if (isHierarchicalPackage &&
+                    TestKindRegistry.JUNIT5_TEST_KIND_ID.equals(getTestRunnerKind(configuration).getId())) {
+                appendPackageNames(launchArguments.programArguments, configuration);
+            }
             return launchArguments;
         } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException |
                 InvocationTargetException e) {
             return null;
+        } finally {
+            fIsHierarchicalPackage = false;
         }
+    }
+
+    /*
+     * Override the super implementation when it is launched in hierarchical mode and starts from
+     * the package level
+     *
+     * @see org.eclipse.jdt.junit.launcher.JUnitLaunchConfigurationDelegate#evaluateTests(
+     *      org.eclipse.debug.core.ILaunchConfiguration, org.eclipse.core.runtime.IProgressMonitor)
+     */
+    @Override
+    protected IMember[] evaluateTests(ILaunchConfiguration configuration, IProgressMonitor monitor)
+            throws CoreException {
+        if (!fIsHierarchicalPackage) {
+            return super.evaluateTests(configuration, monitor);
+        }
+
+        final IPackageFragment testPackage = getTestPackage(configuration);
+        if (testPackage == null) {
+            return super.evaluateTests(configuration, monitor);
+        }
+
+        final IPackageFragment[] packages = TestSearchUtils.getAllSubPackages(testPackage);
+        
+        final HashSet<IType> result = new HashSet<>();
+        final ITestKind testKind = getTestRunnerKind(configuration);
+        for (final IPackageFragment packageFragment : packages) {
+            testKind.getFinder().findTestsInContainer(packageFragment, result, monitor);
+        }
+        
+        if (result.isEmpty()) {
+            final String msg = Messages.format(JUnitMessages.JUnitLaunchConfigurationDelegate_error_notests_kind,
+                testKind.getDisplayName());
+            abort(msg, null, IJavaLaunchConfigurationConstants.ERR_UNSPECIFIED_MAIN_TYPE);
+        }
+        return result.toArray(new IMember[result.size()]);
+    }
+    
+    private IPackageFragment getTestPackage(ILaunchConfiguration configuration) throws CoreException {
+        final String containerHandle = configuration.getAttribute(
+                JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, "");
+        if (containerHandle.length() != 0) {
+            final IJavaElement element = JavaCore.create(containerHandle);
+            if (element == null || !element.exists()) {
+                abort(JUnitMessages.JUnitLaunchConfigurationDelegate_error_input_element_deosn_not_exist, null,
+                        IJavaLaunchConfigurationConstants.ERR_UNSPECIFIED_MAIN_TYPE);
+            }
+            if (element instanceof IPackageFragment) {
+                return (IPackageFragment) element;
+            }
+        }
+        return null;
+    }
+    
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.eclipse.jdt.junit.launcher.JUnitLaunchConfigurationDelegate#getTestRunnerKind(
+     *      org.eclipse.debug.core.ILaunchConfiguration)
+     */
+    private ITestKind getTestRunnerKind(ILaunchConfiguration configuration) {
+        ITestKind testKind = JUnitLaunchConfigurationConstants.getTestRunnerKind(configuration);
+        if (testKind.isNull()) {
+            testKind = TestKindRegistry.getDefault().getKind(TestKindRegistry.JUNIT4_TEST_KIND_ID);
+        }
+        return testKind;
     }
 
     private String[] getVmArguments(VMRunnerConfiguration config) {
@@ -67,6 +164,30 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
         JUnitLaunchUtils.addOverrideDependencies(vmArgs, dependencies);
 
         return vmArgs.toArray(new String[vmArgs.size()]);
+    }
+
+    private void appendPackageNames(String[] programArguments, ILaunchConfiguration configuration) {
+        for (int i = 0; i < programArguments.length; i++) {
+            if ("-packageNameFile".equals(programArguments[i]) && i + 1 < programArguments.length) {
+                final String packageNameFilePath = programArguments[i + 1];
+                final File file = new File(packageNameFilePath);
+                try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file),
+                        StandardCharsets.UTF_8))) {
+                    final IPackageFragment testPackage = getTestPackage(configuration);
+                    if (testPackage == null) {
+                        return;
+                    }
+                    final IPackageFragment[] packages = TestSearchUtils.getAllSubPackages(testPackage);
+                    for (final IPackageFragment pkg : packages) {
+                        bw.write(pkg.getElementName());
+                        bw.newLine();
+                    }
+                } catch (IOException | CoreException e) {
+                    // do nothing
+                }
+                return;
+            }
+        }
     }
 
     public static class JUnitLaunchArguments {

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
@@ -11,7 +11,6 @@
 
 package com.microsoft.java.test.plugin.launchers;
 
-import com.microsoft.java.test.plugin.util.TestSearchUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -24,6 +23,7 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.corext.refactoring.util.JavaElementUtil;
 import org.eclipse.jdt.internal.junit.JUnitMessages;
 import org.eclipse.jdt.internal.junit.Messages;
 import org.eclipse.jdt.internal.junit.launcher.ITestKind;
@@ -106,7 +106,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
             return super.evaluateTests(configuration, monitor);
         }
 
-        final IPackageFragment[] packages = TestSearchUtils.getAllSubPackages(testPackage);
+        final IPackageFragment[] packages = JavaElementUtil.getPackageAndSubpackages(testPackage);
         
         final HashSet<IType> result = new HashSet<>();
         final ITestKind testKind = getTestRunnerKind(configuration);
@@ -181,7 +181,7 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
                     if (testPackage == null) {
                         return;
                     }
-                    final IPackageFragment[] packages = TestSearchUtils.getAllSubPackages(testPackage);
+                    final IPackageFragment[] packages = JavaElementUtil.getPackageAndSubpackages(testPackage);
                     for (final IPackageFragment pkg : packages) {
                         bw.write(pkg.getElementName());
                         bw.newLine();

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
@@ -166,6 +166,10 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
         return vmArgs.toArray(new String[vmArgs.size()]);
     }
 
+    /**
+     * JUnit5's runner will run packages defined in a file, we can add more packages into that file when it's 
+     * run from hierarchical mode to let the runner run test in all the sub-packages.
+     */
     private void appendPackageNames(String[] programArguments, ILaunchConfiguration configuration) {
         for (int i = 0; i < programArguments.length; i++) {
             if ("-packageNameFile".equals(programArguments[i]) && i + 1 < programArguments.length) {

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
@@ -108,7 +108,7 @@ public class JUnitLaunchUtils {
             return resolveTestNGLaunchArguments(configuration, javaProject, delegate);
         }
 
-        return delegate.getJUnitLaunchArguments(configuration, "run", monitor);
+        return delegate.getJUnitLaunchArguments(configuration, "run", args.isHierarchicalPackage, monitor);
     }
 
     public static void addOverrideDependencies(List<String> vmArgs, String dependencies) {
@@ -305,5 +305,6 @@ public class JUnitLaunchUtils {
         public TestKind testKind;
         public Position start;
         public Position end;
+        public boolean isHierarchicalPackage;
     }
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/SearchTestItemParams.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/SearchTestItemParams.java
@@ -18,8 +18,18 @@ public class SearchTestItemParams {
 
     private String fullName;
 
+    private boolean isHierarchicalPackage;
+
     public TestLevel getLevel() {
         return level;
+    }
+
+    public boolean isHierarchicalPackage() {
+        return isHierarchicalPackage;
+    }
+
+    public void setHierarchicalPackage(boolean isHierarchicalPackage) {
+        this.isHierarchicalPackage = isHierarchicalPackage;
     }
 
     public void setLevel(TestLevel level) {

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -49,6 +49,7 @@ import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchParticipant;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.SearchRequestor;
+import org.eclipse.jdt.internal.corext.refactoring.util.JavaElementUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler;
@@ -309,7 +310,7 @@ public class TestSearchUtils {
                 final IJavaElement[] elements;
                 final IJavaElement packageElement = resolvePackage(params.getUri(), params.getFullName());
                 if (params.isHierarchicalPackage()) {
-                    elements = getAllSubPackages(packageElement);
+                    elements = JavaElementUtil.getPackageAndSubpackages((IPackageFragment) packageElement);
                 } else {
                     elements = new IJavaElement[] { packageElement };
                 }
@@ -390,26 +391,6 @@ public class TestSearchUtils {
         }
 
         return element;
-    }
-
-    /**
-     * Get all sub-packages whose name starts with the given package.
-     */
-    public static IPackageFragment[] getAllSubPackages(IJavaElement packageFragment) throws CoreException {
-        final List<IPackageFragment> result = new ArrayList<>();
-        if (packageFragment != null && packageFragment instanceof IPackageFragment) {
-            final IJavaElement[] packages = ((IPackageFragmentRoot) packageFragment.getParent()).getChildren();
-            for (final IJavaElement p : packages) {
-                if (!(p instanceof IPackageFragment)) {
-                    continue;
-                }
-    
-                if (p.getElementName().startsWith(packageFragment.getElementName())) {
-                    result.add((IPackageFragment) p);
-                }
-            }
-        }
-        return result.toArray(new IPackageFragment[result.size()]);
     }
 
     private static void searchInClass(List<TestItem> resultList, SearchTestItemParams params)

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -392,6 +392,9 @@ public class TestSearchUtils {
         return element;
     }
 
+    /**
+     * Get all sub-packages whose name starts with the given package.
+     */
     public static IPackageFragment[] getAllSubPackages(IJavaElement packageFragment) throws CoreException {
         final List<IPackageFragment> result = new ArrayList<>();
         if (packageFragment != null && packageFragment instanceof IPackageFragment) {

--- a/package.json
+++ b/package.json
@@ -123,6 +123,21 @@
                     "command": "java.test.explorer.debug",
                     "when": "view == testExplorer && viewItem != UNTESTABLE_NODE",
                     "group": "inline@1"
+                },
+                {
+                    "command": "java.test.runFromJavaProjectExplorer",
+                    "when": "view == javaProjectExplorer && viewItem =~ /java:(type|package|packageRoot)(?=.*?\\b\\+uri\\b)(?=.*?\\b\\+test\\b)/",
+                    "group": "8_execution@10"
+                },
+                {
+                    "command": "java.test.debugFromJavaProjectExplorer",
+                    "when": "view == javaProjectExplorer && viewItem =~ /java:(type|package|packageRoot)(?=.*?\\b\\+uri\\b)(?=.*?\\b\\+test\\b)/",
+                    "group": "8_execution@20"
+                },
+                {
+                    "command": "java.test.runFromJavaProjectExplorer",
+                    "when": "view == javaProjectExplorer && viewItem =~ /java:(type|package|packageRoot)(?=.*?\\b\\+uri\\b)(?=.*?\\b\\+test\\b)/",
+                    "group": "inline@run_0"
                 }
             ],
             "commandPalette": [
@@ -136,6 +151,14 @@
                 },
                 {
                     "command": "java.test.explorer.refresh",
+                    "when": "false"
+                },
+                {
+                    "command": "java.test.runFromJavaProjectExplorer",
+                    "when": "false"
+                },
+                {
+                    "command": "java.test.debugFromJavaProjectExplorer",
                     "when": "false"
                 },
                 {
@@ -199,6 +222,17 @@
                 "command": "java.test.explorer.runAll",
                 "title": "%contributes.commands.java.test.explorer.runAll.title%",
                 "icon": "$(run-all)",
+                "category": "Java"
+            },
+            {
+                "command": "java.test.runFromJavaProjectExplorer",
+                "title": "%contributes.commands.java.test.runFromJavaProjectExplorer%",
+                "icon": "$(play)",
+                "category": "Java"
+            },
+            {
+                "command": "java.test.debugFromJavaProjectExplorer",
+                "title": "%contributes.commands.java.test.debugFromJavaProjectExplorer%",
                 "category": "Java"
             },
             {

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,6 +11,8 @@
     "contributes.commands.java.test.show.report.title": "Show Test Report",
     "contributes.commands.java.test.editor.run.title": "Run Tests",
     "contributes.commands.java.test.editor.debug.title": "Debug Tests",
+    "contributes.commands.java.test.runFromJavaProjectExplorer": "Run Tests",
+    "contributes.commands.java.test.debugFromJavaProjectExplorer": "Debug Tests",
     "contributes.commands.java.test.relaunch.title": "Relaunch the Tests",
     "contributes.commands.java.test.cancel.title": "Cancel Test Job",
     "contributes.commands.java.test.explorer.refresh.title": "Refresh",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -13,6 +13,8 @@
     "contributes.commands.java.test.editor.debug.title": "调试测试用例",
     "contributes.commands.java.test.relaunch.title": "重新执行测试任务",
     "contributes.commands.java.test.cancel.title": "取消测试任务",
+    "contributes.commands.java.test.runFromJavaProjectExplorer": "运行测试",
+    "contributes.commands.java.test.debugFromJavaProjectExplorer": "调试测试",
     "contributes.commands.java.test.explorer.refresh.title": "刷新",
     "contributes.commands.java.test.config.migrate.title": "迁移已弃用的 'launch.test.json' 文件",
     "configuration.java.test.report.showAfterExecution.description": "设定测试报告是否会在测试完成后自动显示",

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -26,6 +26,8 @@ export namespace JavaTestRunnerCommands {
     export const DEBUG_ALL_TEST_FROM_EXPLORER: string = 'java.test.explorer.debugAll';
     export const RUN_ALL_TEST_FROM_EXPLORER: string = 'java.test.explorer.runAll';
     export const DEBUG_TEST_FROM_EXPLORER: string = 'java.test.explorer.debug';
+    export const RUN_TEST_FROM_JAVA_PROJECT_EXPLORER: string = 'java.test.runFromJavaProjectExplorer';
+    export const DEBUG_TEST_FROM_JAVA_PROJECT_EXPLORER: string = 'java.test.debugFromJavaProjectExplorer';
     export const SHOW_TEST_REPORT: string = 'java.test.show.report';
     export const SHOW_TEST_OUTPUT: string = 'java.test.show.output';
     export const OPEN_TEST_LOG: string = 'java.test.open.log';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { commands, DebugConfiguration, Event, Extension, ExtensionContext, exten
 import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentOperation, instrumentOperationAsVsCodeCommand } from 'vscode-extension-telemetry-wrapper';
 import { sendInfo } from 'vscode-extension-telemetry-wrapper';
 import { testCodeLensController } from './codelens/TestCodeLensController';
-import { debugTestsFromExplorer, openTextDocument, runTestsFromExplorer } from './commands/explorerCommands';
+import { debugTestsFromExplorer, openTextDocument, runTestsFromExplorer, runTestsFromJavaProjectExplorer } from './commands/explorerCommands';
 import { openLogFile, showOutputChannel } from './commands/logCommands';
 import { runFromCodeLens } from './commands/runFromCodeLens';
 import { executeTestsFromUri } from './commands/runFromUri';
@@ -118,6 +118,8 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.DEBUG_TEST_FROM_EDITOR, async (uri?: Uri, progressReporter?: IProgressReporter) => await executeTestsFromUri(uri, progressReporter, true /* isDebug */)),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.JAVA_TEST_REPORT_OPEN_STACKTRACE, async (trace: string, fullName: string) => await openStackTrace(trace, fullName)),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.JAVA_TEST_REPORT_OPEN_TEST_SOURCE_LOCATION, async (uri: string, range: string, fullName: string) => await openTestSourceLocation(uri, range, fullName)),
+        instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.RUN_TEST_FROM_JAVA_PROJECT_EXPLORER, async (node: any) => await runTestsFromJavaProjectExplorer(node, false /* isDebug */)),
+        instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.DEBUG_TEST_FROM_JAVA_PROJECT_EXPLORER, async (node: any) => await runTestsFromJavaProjectExplorer(node, true /* isDebug */)),
     );
 
     setContextKeyForDeprecatedConfig();

--- a/src/protocols.ts
+++ b/src/protocols.ts
@@ -23,6 +23,7 @@ export interface ISearchTestItemParams {
     level: TestLevel;
     fullName: string;
     uri: string;
+    isHierarchicalPackage?: boolean;
 }
 
 export enum TestLevel {

--- a/src/runners/models.ts
+++ b/src/runners/models.ts
@@ -38,4 +38,5 @@ export interface IRunnerContext {
     isDebug: boolean;
     kind: TestKind;
     tests: ITestItem[];
+    isHierarchicalPackage?: boolean;
 }

--- a/src/testItemModel.ts
+++ b/src/testItemModel.ts
@@ -23,9 +23,12 @@ class TestItemModel implements Disposable {
         return this.save(childrenNodes);
     }
 
-    public async getAllNodes(level: TestLevel, fullName: string, uri: string, token: CancellationToken): Promise<ITestItem[]> {
+    public async getAllNodes(level: TestLevel, fullName: string, uri: string, isHierarchicalPackage: boolean | undefined, token: CancellationToken): Promise<ITestItem[]> {
         const searchParam: ISearchTestItemParams = constructSearchTestItemParams(level, fullName, uri);
-        const tests: ITestItem[] = await searchTestItemsAll(searchParam, token);
+        const tests: ITestItem[] = await searchTestItemsAll({
+            ...searchParam,
+            isHierarchicalPackage,
+        }, token);
         if (token.isCancellationRequested) {
             return [];
         }

--- a/src/utils/commandUtils.ts
+++ b/src/utils/commandUtils.ts
@@ -42,7 +42,8 @@ export async function resolveStackTraceLocation(trace: string, projectNames: str
 }
 
 export async function resolveJUnitLaunchArguments(uri: string, classFullName: string, testName: string, project: string,
-                                                  scope: TestLevel, testKind: TestKind, start?: Position, end?: Position): Promise<IJUnitLaunchArguments> {
+                                                  scope: TestLevel, testKind: TestKind, start?: Position, end?: Position,
+                                                  isHierarchicalPackage?: boolean): Promise<IJUnitLaunchArguments> {
     const argument: IJUnitLaunchArguments | undefined = await executeJavaLanguageServerCommand<IJUnitLaunchArguments>(
         JavaTestRunnerDelegateCommands.RESOLVE_JUNIT_ARGUMENT, JSON.stringify({
             uri,
@@ -53,6 +54,7 @@ export async function resolveJUnitLaunchArguments(uri: string, classFullName: st
             testKind,
             start,
             end,
+            isHierarchicalPackage,
         }));
 
     if (!argument) {

--- a/src/utils/launchUtils.ts
+++ b/src/utils/launchUtils.ts
@@ -102,7 +102,7 @@ async function getJUnitLaunchArguments(runnerContext: IRunnerContext): Promise<I
         end = runnerContext.tests[0].location.range.end;
     }
 
-    return await resolveJUnitLaunchArguments(runnerContext.testUri, className, methodName, runnerContext.projectName, runnerContext.scope, runnerContext.kind, start, end);
+    return await resolveJUnitLaunchArguments(runnerContext.testUri, className, methodName, runnerContext.projectName, runnerContext.scope, runnerContext.kind, start, end, runnerContext.isHierarchicalPackage);
 }
 
 async function getTestNGLaunchArguments(projectName: string): Promise<IJUnitLaunchArguments> {


### PR DESCRIPTION
Support run tests from the Java Project explorer

### Demo

https://user-images.githubusercontent.com/6193897/104272416-05afab80-54d8-11eb-9542-03ff98789c5b.mp4

### Note
Since we need to run all the children nodes if the explorer is in Hierarchical mode, so I made some workaround in the implementation. Basically it's to patch the arguments resolved by the configuration delegator.

