### PR TITLE
fix: Improve the accessibility of opening document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,9 +159,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.51.0.tgz",
-            "integrity": "sha512-C/jZ35OT5k/rsJyAK8mS1kM++vMcm89oSWegkzxRCvHllIq0cToZAkIDs6eCY4SKrvik3nrhELizyLcM0onbQA==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+            "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
             "dev": true
         },
         "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ],
     "aiKey": "90c182a8-8dab-45d4-bfb8-1353eb55aa7f",
     "engines": {
-        "vscode": "^1.51.0"
+        "vscode": "^1.52.0"
     },
     "categories": [
         "Other"
@@ -457,7 +457,7 @@
         "@types/node": "^14.0.1",
         "@types/pug": "^2.0.4",
         "@types/sinon": "^9.0.3",
-        "@types/vscode": "1.51.0",
+        "@types/vscode": "1.52.0",
         "bootstrap": "^4.5.0",
         "filemanager-webpack-plugin": "^2.0.5",
         "gulp": "^4.0.2",

--- a/src/commands/explorerCommands.ts
+++ b/src/commands/explorerCommands.ts
@@ -13,7 +13,7 @@ import { executeTestsFromUri } from './runFromUri';
 
 export async function openTextDocument(uri: Uri, range?: Range): Promise<void> {
     const document: TextDocument = await workspace.openTextDocument(uri);
-    await window.showTextDocument(document, {preserveFocus: true, selection: range, viewColumn: ViewColumn.One});
+    await window.showTextDocument(document, {selection: range, viewColumn: ViewColumn.One});
 }
 
 export async function runTestsFromExplorer(node?: ITestItem, launchConfiguration?: DebugConfiguration): Promise<void> {

--- a/src/commands/testReportCommands.ts
+++ b/src/commands/testReportCommands.ts
@@ -3,9 +3,9 @@
 
 import { commands, Position, QuickPickItem, Range, Uri, ViewColumn, window } from 'vscode';
 import { ILocation } from '../../extension.bundle';
+import { JavaTestRunnerCommands } from '../constants/commands';
 import { logger } from '../logger/logger';
 import { resolveStackTraceLocation, searchTestLocation } from '../utils/commandUtils';
-import { openTextDocument } from './explorerCommands';
 
 export async function openStackTrace(trace: string, fullName: string): Promise<void> {
     if (!trace || !fullName) {
@@ -22,7 +22,6 @@ export async function openStackTrace(trace: string, fullName: string): Promise<v
             lineNumber = parseInt(lineNumberGroup[1], 10) - 1;
         }
         await window.showTextDocument(Uri.parse(uri), {
-            preserveFocus: true,
             selection: new Range(new Position(lineNumber, 0), new Position(lineNumber + 1, 0)),
             viewColumn: ViewColumn.One,
         });
@@ -38,17 +37,17 @@ export async function openStackTrace(trace: string, fullName: string): Promise<v
 
 export async function openTestSourceLocation(uri: string, range: string, fullName: string): Promise<void> {
     if (uri && range) {
-        return openTextDocument(Uri.parse(uri), JSON.parse(range) as Range);
+        return commands.executeCommand(JavaTestRunnerCommands.OPEN_DOCUMENT, Uri.parse(uri), JSON.parse(range) as Range);
     } else if (fullName) {
         const items: ILocation[] = await searchTestLocation(fullName.slice(fullName.indexOf('@') + 1));
         if (items.length === 1) {
-            return openTextDocument(Uri.parse(items[0].uri), items[0].range);
+            return commands.executeCommand(JavaTestRunnerCommands.OPEN_DOCUMENT, Uri.parse(items[0].uri), items[0].range);
         } else if (items.length > 1) {
             const pick: ILocationQuickPick | undefined = await window.showQuickPick(items.map((item: ILocation) => {
                 return { label: fullName, detail: Uri.parse(item.uri).fsPath, location: item };
             }), { placeHolder: 'Select the file you want to navigate to' });
             if (pick) {
-                return openTextDocument(Uri.parse(pick.location.uri), pick.location.range);
+                return commands.executeCommand(JavaTestRunnerCommands.OPEN_DOCUMENT, Uri.parse(pick.location.uri), pick.location.range);
             }
         } else {
             logger.error('No test item could be found from Language Server.');

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -37,3 +37,7 @@ export namespace JavaTestRunnerCommands {
     export const JAVA_TEST_REPORT_OPEN_STACKTRACE: string = 'java.test.report.openStackTrace';
     export const JAVA_TEST_REPORT_OPEN_TEST_SOURCE_LOCATION: string = 'java.test.report.openTestSourceLocation';
 }
+
+export namespace VsCodeCommands {
+    export const VSCODE_OPEN: string = 'vscode.open';
+}

--- a/src/explorer/testExplorer.ts
+++ b/src/explorer/testExplorer.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import { Command, Disposable, Event, EventEmitter, ExtensionContext, extensions, Range, ThemeColor, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri, workspace, WorkspaceFolder } from 'vscode';
-import { JavaTestRunnerCommands } from '../constants/commands';
+import { VsCodeCommands } from '../constants/commands';
 import { isLightWeightMode, isSwitchingServer } from '../extension';
 import { ITestItem, TestKind, TestLevel } from '../protocols';
 import { ITestResult, TestStatus } from '../runners/models';
@@ -128,9 +128,9 @@ export class TestExplorer implements TreeDataProvider<ITestItem>, Disposable {
     private resolveCommand(element: ITestItem): Command | undefined {
         if (element.level >= TestLevel.Class) {
             return {
-                command: JavaTestRunnerCommands.OPEN_DOCUMENT,
-                title: '',
-                arguments: [Uri.parse(element.location.uri), element.location.range],
+                command: VsCodeCommands.VSCODE_OPEN,
+                title: 'Open File',
+                arguments: [Uri.parse(element.location.uri), { preserveFocus: true, selection: element.location.range }],
             };
         }
         return undefined;

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -7,6 +7,7 @@ import * as _ from 'lodash';
 import * as path from 'path';
 import { commands, ConfigurationTarget, QuickPickItem, TextDocument, Uri, window, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
 import { sendInfo } from 'vscode-extension-telemetry-wrapper';
+import { VsCodeCommands } from '../constants/commands';
 import { BUILTIN_CONFIG_NAME, CONFIG_DOCUMENT_URL, CONFIG_SETTING_KEY, DEFAULT_CONFIG_NAME_SETTING_KEY, HINT_FOR_DEFAULT_CONFIG_SETTING_KEY } from '../constants/configs';
 import { LEARN_MORE, NEVER_SHOW, NO, OPEN_SETTING, YES } from '../constants/dialogOptions';
 import { logger } from '../logger/logger';
@@ -90,7 +91,7 @@ export async function migrateTestConfig(): Promise<void> {
             await window.showTextDocument(document, { preview: false });
         }
     } else if (choice === LEARN_MORE) {
-        commands.executeCommand('vscode.open', Uri.parse(CONFIG_DOCUMENT_URL));
+        commands.executeCommand(VsCodeCommands.VSCODE_OPEN, Uri.parse(CONFIG_DOCUMENT_URL));
     }
 }
 


### PR DESCRIPTION
This PR contains following changes:
- Use the VS Code built-in `open` command for the tree nodes in the test explorer
- Since using the built-in command will lose the BI, using a event counter to track the ui operations
- Better treat with the focus when opening documents from the test report.

Related with #1128