### PR TITLE
refactor: Leverage test finder for test discovery

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
@@ -143,7 +143,7 @@ public class JUnitLaunchUtils {
         String testName = StringUtils.isEmpty(args.testName) ? "" : args.testName;
         // JUnit 5's methods need to have parameter information to launch
         if (args.testKind == TestKind.JUnit5 && args.scope == TestLevel.METHOD) {
-            final ASTNode unit = TestSearchUtils.parseToAst(cu, monitor);
+            final ASTNode unit = TestSearchUtils.parseToAst(cu, true /*fromCache*/, monitor);
             if (unit == null) {
                 return "";
             }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/TestItem.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/model/TestItem.java
@@ -42,7 +42,7 @@ public class TestItem {
         this.kind = kind;
         this.project = project;
         this.location = new Location(uri, range);
-        this.id = String.format("%s@%s", project, fullName);
+        this.id = project + "@" + fullName;
     }
 
     public String getId() {

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/BaseFrameworkSearcher.java
@@ -18,18 +18,14 @@ import com.microsoft.java.test.plugin.util.TestFrameworkUtils;
 import com.microsoft.java.test.plugin.util.TestItemUtils;
 
 import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
-import org.eclipse.jdt.core.search.IJavaSearchConstants;
-import org.eclipse.jdt.core.search.SearchPattern;
 
 public abstract class BaseFrameworkSearcher implements TestFrameworkSearcher {
 
     protected String[] testMethodAnnotations;
-    protected String[] testClassAnnotations;
 
     @Override
     public abstract TestKind getTestKind();
@@ -37,44 +33,6 @@ public abstract class BaseFrameworkSearcher implements TestFrameworkSearcher {
     @Override
     public String[] getTestMethodAnnotations() {
         return this.testMethodAnnotations;
-    }
-
-    @Override
-    public String[] getTestClassAnnotations() {
-        return this.testClassAnnotations;
-    }
-
-    @Override
-    public boolean isTestClass(IType type) {
-        for (final String annotation : this.getTestClassAnnotations()) {
-            if (TestFrameworkUtils.hasAnnotation(type, annotation, false /*checkHierarchy*/)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public SearchPattern getSearchPattern() {
-        if (this.getTestMethodAnnotations().length <= 0) {
-            throw new RuntimeException(
-                    "Failed to initialize the supported test annotations for " + this.getClass().getName());
-        }
-        SearchPattern searchPattern = SearchPattern.createPattern(this.getTestMethodAnnotations()[0],
-                IJavaSearchConstants.ANNOTATION_TYPE, IJavaSearchConstants.ANNOTATION_TYPE_REFERENCE,
-                SearchPattern.R_EXACT_MATCH);
-        for (int i = 1; i < this.getTestMethodAnnotations().length; i++) {
-            searchPattern = SearchPattern.createOrPattern(searchPattern,
-                    SearchPattern.createPattern(this.getTestMethodAnnotations()[i],
-                            IJavaSearchConstants.ANNOTATION_TYPE, IJavaSearchConstants.ANNOTATION_TYPE_REFERENCE,
-                            SearchPattern.R_EXACT_MATCH));
-        }
-        for (final String classAnnotation : this.getTestClassAnnotations()) {
-            searchPattern = SearchPattern.createOrPattern(searchPattern,
-                    SearchPattern.createPattern(classAnnotation, IJavaSearchConstants.ANNOTATION_TYPE,
-                            IJavaSearchConstants.ANNOTATION_TYPE_REFERENCE, SearchPattern.R_EXACT_MATCH));
-        }
-        return searchPattern;
     }
 
     @Override
@@ -88,16 +46,6 @@ public abstract class BaseFrameworkSearcher implements TestFrameworkSearcher {
             }
         }
         return false;
-    }
-
-    @Override
-    public TestItem parseTestItem(IMethod method) throws JavaModelException {
-        return TestItemUtils.constructTestItem(method, TestLevel.METHOD, this.getTestKind());
-    }
-
-    @Override
-    public TestItem parseTestItem(IType type) throws JavaModelException {
-        return TestItemUtils.constructTestItem(type, TestLevel.CLASS, this.getTestKind());
     }
 
     @Override

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
@@ -11,24 +11,35 @@
 
 package com.microsoft.java.test.plugin.searcher;
 
+import com.microsoft.java.test.plugin.model.TestItem;
 import com.microsoft.java.test.plugin.model.TestKind;
-import com.microsoft.java.test.plugin.util.TestFrameworkUtils;
+import com.microsoft.java.test.plugin.model.TestLevel;
+import com.microsoft.java.test.plugin.util.TestItemUtils;
 
-import org.eclipse.jdt.core.Flags;
-import org.eclipse.jdt.core.IMethod;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.internal.junit.launcher.JUnit4TestFinder;
 import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class JUnit4TestSearcher extends BaseFrameworkSearcher {
 
-    public static final String RUN_WITH = "org.junit.runner.RunWith";
+    private static final JUnit4TestFinder JUNIT4_TEST_FINDER = new JUnit4TestFinder();
 
     public JUnit4TestSearcher() {
         super();
         this.testMethodAnnotations = new String[] { "org.junit.Test", "org.junit.experimental.theories.Theory" };
-        this.testClassAnnotations = new String[] { RUN_WITH };
     }
 
     @Override
@@ -39,29 +50,6 @@ public class JUnit4TestSearcher extends BaseFrameworkSearcher {
     @Override
     public String getJdtTestKind() {
         return TestKindRegistry.JUNIT4_TEST_KIND_ID;
-    }
-
-    @Override
-    public boolean isTestMethod(IMethod method) {
-        try {
-            final int flags = method.getFlags();
-            if (Flags.isAbstract(flags) || Flags.isStatic(flags) || !Flags.isPublic(flags)) {
-                return false;
-            }
-            // 'V' is void signature
-            if (method.isConstructor() || !"V".equals(method.getReturnType())) {
-                return false;
-            }
-            for (final String annotation : this.testMethodAnnotations) {
-                if (TestFrameworkUtils.hasAnnotation(method, annotation, false /*checkHierarchy*/)) {
-                    return true;
-                }
-            }
-            return false;
-        } catch (final JavaModelException e) {
-            // ignore
-            return false;
-        }
     }
 
     @Override
@@ -76,5 +64,28 @@ public class JUnit4TestSearcher extends BaseFrameworkSearcher {
         }
 
         return this.findAnnotation(methodBinding.getAnnotations(), this.getTestMethodAnnotations());
+    }
+
+    @Override
+    public boolean isTestClass(IType type) throws JavaModelException {
+        return JUNIT4_TEST_FINDER.isTest(type);
+    }
+
+    @Override
+    public TestItem[] findTestsInContainer(IJavaElement element, IProgressMonitor monitor) throws CoreException {
+        final Map<String, TestItem> result = new HashMap<>();
+        final Set<IType> types = new HashSet<>();
+        JUNIT4_TEST_FINDER.findTestsInContainer(element, types, monitor);
+        for (final IType type : types) {
+            final TestItem item = TestItemUtils.constructTestItem(type, TestLevel.CLASS, TestKind.JUnit);
+            item.setChildren(Arrays.stream(type.getMethods())
+                    .map(m -> String.format("%s@%s", m.getJavaProject().getProject().getName(),
+                            TestItemUtils.parseTestItemFullName(m, TestLevel.METHOD)))
+                    .collect(Collectors.toList())
+            );
+            result.put(item.getId(), item);
+        }
+
+        return result.values().toArray(new TestItem[0]);
     }
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit4TestSearcher.java
@@ -79,8 +79,8 @@ public class JUnit4TestSearcher extends BaseFrameworkSearcher {
         for (final IType type : types) {
             final TestItem item = TestItemUtils.constructTestItem(type, TestLevel.CLASS, TestKind.JUnit);
             item.setChildren(Arrays.stream(type.getMethods())
-                    .map(m -> String.format("%s@%s", m.getJavaProject().getProject().getName(),
-                            TestItemUtils.parseTestItemFullName(m, TestLevel.METHOD)))
+                    .map(m -> m.getJavaProject().getProject().getName() + "@" +
+                            TestItemUtils.parseTestItemFullName(m, TestLevel.METHOD))
                     .collect(Collectors.toList())
             );
             result.put(item.getId(), item);

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
@@ -13,42 +13,41 @@ package com.microsoft.java.test.plugin.searcher;
 
 import com.microsoft.java.test.plugin.model.TestItem;
 import com.microsoft.java.test.plugin.model.TestKind;
+import com.microsoft.java.test.plugin.model.TestLevel;
 import com.microsoft.java.test.plugin.util.TestFrameworkUtils;
+import com.microsoft.java.test.plugin.util.TestItemUtils;
 
-import org.eclipse.jdt.core.Flags;
-import org.eclipse.jdt.core.IAnnotation;
-import org.eclipse.jdt.core.IMethod;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.internal.junit.launcher.JUnit5TestFinder;
 import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class JUnit5TestSearcher extends BaseFrameworkSearcher {
 
+    private static final JUnit5TestFinder JUNIT5_TEST_FINDER = new JUnit5TestFinder();
+
     public static final String JUPITER_NESTED = "org.junit.jupiter.api.Nested";
     public static final String JUNIT_PLATFORM_TESTABLE = "org.junit.platform.commons.annotation.Testable";
-
-    // TODO: Remove the following annotations once we can find tests without the search engine
-    //       - The search engine cannot find the meta-annotation and testable annotated ones.
-    public static final String JUPITER_TEST = "org.junit.jupiter.api.Test";
-    public static final String JUPITER_PARAMETERIZED_TEST = "org.junit.jupiter.params.ParameterizedTest";
-    public static final String JUPITER_REPEATED_TEST = "org.junit.jupiter.api.RepeatedTest";
-    public static final String JUPITER_TEST_FACTORY = "org.junit.jupiter.api.TestFactory";
-    public static final String JUPITER_TEST_TEMPLATE = "org.junit.jupiter.api.TestTemplate";
 
     protected static final String DISPLAY_NAME_ANNOTATION_JUNIT5 = "org.junit.jupiter.api.DisplayName";
 
     public JUnit5TestSearcher() {
         super();
-        this.testMethodAnnotations = new String[] { JUPITER_TEST, JUPITER_PARAMETERIZED_TEST,
-            JUPITER_REPEATED_TEST, JUPITER_TEST_FACTORY, JUPITER_TEST_TEMPLATE, JUNIT_PLATFORM_TESTABLE };
-        this.testClassAnnotations = new String[] { JUNIT_PLATFORM_TESTABLE, JUPITER_NESTED };
+        this.testMethodAnnotations = new String[] { JUNIT_PLATFORM_TESTABLE };
     }
 
     @Override
@@ -59,28 +58,6 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
     @Override
     public String getJdtTestKind() {
         return TestKindRegistry.JUNIT5_TEST_KIND_ID;
-    }
-
-    @Override
-    public boolean isTestMethod(IMethod method) {
-        try {
-            final int flags = method.getFlags();
-            if (Flags.isAbstract(flags) || Flags.isStatic(flags) || Flags.isPrivate(flags)) {
-                return false;
-            }
-            if (method.isConstructor()) {
-                return false;
-            }
-            for (final String annotation : this.testMethodAnnotations) {
-                if (TestFrameworkUtils.hasAnnotation(method, annotation, true /*checkHierarchy*/)) {
-                    return true;
-                }
-            }
-            return false;
-        } catch (final JavaModelException e) {
-            // ignore
-            return false;
-        }
     }
 
     @Override
@@ -95,20 +72,6 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
         }
 
         return this.findAnnotation(methodBinding.getAnnotations(), this.getTestMethodAnnotations());
-    }
-
-    @SuppressWarnings("rawtypes")
-    @Override
-    public TestItem parseTestItem(IMethod method) throws JavaModelException {
-        final TestItem item = super.parseTestItem(method);
-        // Check if the method has annotated with @DisplayName
-        final Optional<IAnnotation> annotation = TestFrameworkUtils.getAnnotation(method,
-                DISPLAY_NAME_ANNOTATION_JUNIT5, false /*checkHierarchy*/);
-        if (annotation.isPresent()) {
-            item.setDisplayName((String) annotation.get().getMemberValuePairs()[0].getValue());
-        }
-
-        return item;
     }
 
     @Override
@@ -149,6 +112,29 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean isTestClass(IType type) throws JavaModelException {
+        return JUNIT5_TEST_FINDER.isTest(type);
+    }
+
+    @Override
+    public TestItem[] findTestsInContainer(IJavaElement element, IProgressMonitor monitor) throws CoreException {
+        final Map<String, TestItem> result = new HashMap<>();
+        final Set<IType> types = new HashSet<>();
+        JUNIT5_TEST_FINDER.findTestsInContainer(element, types, monitor);
+        for (final IType type : types) {
+            final TestItem item = TestItemUtils.constructTestItem(type, TestLevel.CLASS, TestKind.JUnit5);
+            item.setChildren(Arrays.stream(type.getMethods())
+                    .map(m -> String.format("%s@%s", m.getJavaProject().getProject().getName(),
+                            TestItemUtils.parseTestItemFullName(m, TestLevel.METHOD)))
+                    .collect(Collectors.toList())
+            );
+            result.put(item.getId(), item);
+        }
+
+        return result.values().toArray(new TestItem[0]);
     }
 
     private boolean matchesName(ITypeBinding annotationType, String annotationName) {

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/JUnit5TestSearcher.java
@@ -127,8 +127,8 @@ public class JUnit5TestSearcher extends BaseFrameworkSearcher {
         for (final IType type : types) {
             final TestItem item = TestItemUtils.constructTestItem(type, TestLevel.CLASS, TestKind.JUnit5);
             item.setChildren(Arrays.stream(type.getMethods())
-                    .map(m -> String.format("%s@%s", m.getJavaProject().getProject().getName(),
-                            TestItemUtils.parseTestItemFullName(m, TestLevel.METHOD)))
+                    .map(m ->m.getJavaProject().getProject().getName() + "@" +
+                            TestItemUtils.parseTestItemFullName(m, TestLevel.METHOD))
                     .collect(Collectors.toList())
             );
             result.put(item.getId(), item);

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestFrameworkSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestFrameworkSearcher.java
@@ -14,12 +14,13 @@ package com.microsoft.java.test.plugin.searcher;
 import com.microsoft.java.test.plugin.model.TestItem;
 import com.microsoft.java.test.plugin.model.TestKind;
 
-import org.eclipse.jdt.core.IMethod;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
-import org.eclipse.jdt.core.search.SearchPattern;
 
 public interface TestFrameworkSearcher {
 
@@ -27,25 +28,15 @@ public interface TestFrameworkSearcher {
 
     String getJdtTestKind();
 
-    @Deprecated
-    boolean isTestMethod(IMethod method);
-
     boolean isTestMethod(IMethodBinding methodBinding);
 
-    boolean isTestClass(IType type);
+    boolean isTestClass(IType type) throws JavaModelException;
 
     String[] getTestMethodAnnotations();
 
-    String[] getTestClassAnnotations();
-
-    SearchPattern getSearchPattern();
-
     boolean findAnnotation(IAnnotationBinding[] annotations, String[] annotationNames);
-
-    @Deprecated
-    TestItem parseTestItem(IMethod method) throws JavaModelException;
 
     TestItem parseTestItem(IMethodBinding methodBinding) throws JavaModelException;
 
-    TestItem parseTestItem(IType type) throws JavaModelException;
+    TestItem[] findTestsInContainer(IJavaElement element, IProgressMonitor monitor) throws CoreException;
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
@@ -11,21 +11,57 @@
 
 package com.microsoft.java.test.plugin.searcher;
 
+import com.microsoft.java.test.plugin.model.TestItem;
 import com.microsoft.java.test.plugin.model.TestKind;
-import com.microsoft.java.test.plugin.util.TestFrameworkUtils;
+import com.microsoft.java.test.plugin.model.TestLevel;
+import com.microsoft.java.test.plugin.util.TestItemUtils;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IRegion;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
+import org.eclipse.jdt.internal.junit.util.CoreTestSearchEngine;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class TestNGTestSearcher extends BaseFrameworkSearcher {
 
     public TestNGTestSearcher() {
         super();
         this.testMethodAnnotations = new String[] { "org.testng.annotations.Test" };
-        this.testClassAnnotations = new String[] {};
     }
 
     @Override
@@ -39,30 +75,7 @@ public class TestNGTestSearcher extends BaseFrameworkSearcher {
     }
 
     @Override
-    public boolean isTestMethod(IMethod method) {
-        try {
-            final int flags = method.getFlags();
-            if (Flags.isAbstract(flags) || Flags.isStatic(flags)) {
-                return false;
-            }
-            // 'V' is void signature
-            if (method.isConstructor() || !"V".equals(method.getReturnType())) {
-                return false;
-            }
-            for (final String annotation : this.testMethodAnnotations) {
-                if (TestFrameworkUtils.hasAnnotation(method, annotation, false /*checkHierarchy*/)) {
-                    return true;
-                }
-            }
-            return false;
-        } catch (final JavaModelException e) {
-            // ignore
-            return false;
-        }
-    }
-
-    @Override
-    public boolean isTestMethod(IMethodBinding methodBinding) {
+    public boolean isTestMethod(final IMethodBinding methodBinding) {
         final int modifiers = methodBinding.getModifiers();
         if (Modifier.isAbstract(modifiers) || Modifier.isStatic(modifiers)) {
             return false;
@@ -72,5 +85,196 @@ public class TestNGTestSearcher extends BaseFrameworkSearcher {
             return false;
         }
         return this.findAnnotation(methodBinding.getAnnotations(), this.getTestMethodAnnotations());
+    }
+
+    @Override
+    public boolean isTestClass(final IType type) throws JavaModelException {
+        return internalIsTest(type, null);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.testng.eclipse.launch.TestFinder#internalIsTest
+     */
+    private boolean internalIsTest(final IType type, final IProgressMonitor monitor) throws JavaModelException {
+        if (CoreTestSearchEngine.isAccessibleClass(type)) {
+            final ASTParser parser = ASTParser.newParser(AST.JLS14);
+            /*
+             * TODO: When bug 156352 is fixed: parser.setProject(type.getJavaProject());
+             * IBinding[] bindings= parser.createBindings(new IJavaElement[] { type },
+             * monitor); if (bindings.length == 1 && bindings[0] instanceof ITypeBinding) {
+             * ITypeBinding binding= (ITypeBinding) bindings[0]; return isTest(binding); }
+             */
+
+            if (type.getCompilationUnit() != null) {
+                parser.setSource(type.getCompilationUnit());
+            } else if (!isAvailable(type.getSourceRange())) { // class file with no source
+                parser.setProject(type.getJavaProject());
+                final IBinding[] bindings = parser.createBindings(new IJavaElement[] { type }, monitor);
+                if (bindings.length == 1 && bindings[0] instanceof ITypeBinding) {
+                    final ITypeBinding binding = (ITypeBinding) bindings[0];
+                    return isTest(binding);
+                }
+                return false;
+            } else {
+                parser.setSource(type.getClassFile());
+            }
+            parser.setFocalPosition(0);
+            parser.setIgnoreMethodBodies(true);
+            parser.setResolveBindings(true);
+            final CompilationUnit root = (CompilationUnit) parser.createAST(monitor);
+            final ASTNode node = root.findDeclaringNode(type.getKey());
+            if (node instanceof TypeDeclaration) {
+                final ITypeBinding binding = ((TypeDeclaration) node).resolveBinding();
+                if (binding != null) {
+                    return isTest(binding);
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isAvailable(final ISourceRange range) {
+        return range != null && range.getOffset() != -1;
+    }
+
+    private boolean isTest(final ITypeBinding binding) {
+        if (Modifier.isAbstract(binding.getModifiers())) {
+            return false;
+        }
+
+        return annotatesAtLeastOneMethod(binding, "org.testng.annotations.Test");
+    }
+
+    public boolean annotatesAtLeastOneMethod(ITypeBinding type, final String qualifiedName) {
+        while (type != null) {
+            final IMethodBinding[] declaredMethods = type.getDeclaredMethods();
+            for (int i = 0; i < declaredMethods.length; i++) {
+                final IMethodBinding curr = declaredMethods[i];
+                if (annotates(curr.getAnnotations(), qualifiedName)) {
+                    return true;
+                }
+            }
+            type = type.getSuperclass();
+        }
+        return false;
+    }
+
+    private boolean annotates(final IAnnotationBinding[] annotations, final String qualifiedName) {
+        for (int i = 0; i < annotations.length; i++) {
+            final ITypeBinding annotationType = annotations[i].getAnnotationType();
+            if (annotationType != null && (annotationType.getQualifiedName().equals(qualifiedName))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public TestItem[] findTestsInContainer(final IJavaElement element, final IProgressMonitor monitor)
+            throws CoreException {
+        final Map<String, TestItem> result = new HashMap<>();
+        final Set<IType> types = new HashSet<>();
+        findTestsInContainer(element, types, monitor);
+        for (final IType type : types) {
+            final TestItem item = TestItemUtils.constructTestItem(type, TestLevel.CLASS, TestKind.TestNG);
+            item.setChildren(
+                    Arrays.stream(type.getMethods())
+                            .map(m -> String.format("%s@%s", m.getJavaProject().getProject().getName(),
+                                    TestItemUtils.parseTestItemFullName(m, TestLevel.METHOD)))
+                            .collect(Collectors.toList()));
+            result.put(item.getId(), item);
+        }
+
+        return result.values().toArray(new TestItem[0]);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.testng.eclipse.launch.TestFinder#findTestsInContainer
+     */
+    private void findTestsInContainer(final IJavaElement element, final Set result, IProgressMonitor pm)
+            throws CoreException {
+        if (element == null || result == null) {
+            throw new IllegalArgumentException();
+        }
+
+        if (element instanceof IType) {
+            if (internalIsTest((IType) element, pm)) {
+                result.add(element);
+                return;
+            }
+        }
+
+        if (pm == null) {
+            pm = new NullProgressMonitor();
+        }
+
+        try {
+            final IRegion region = CoreTestSearchEngine.getRegion(element);
+            final ITypeHierarchy hierarchy = JavaCore.newTypeHierarchy(region, null, new SubProgressMonitor(pm, 1));
+            final IType[] allClasses = hierarchy.getAllClasses();
+
+            // search for all types with references to RunWith and Test and all subclasses
+            final Set<IType> candidates = new HashSet<>(allClasses.length);
+            final SearchRequestor requestor = new AnnotationSearchRequestor(hierarchy, candidates);
+            final IJavaSearchScope scope = SearchEngine.createJavaSearchScope(allClasses, IJavaSearchScope.SOURCES);
+            final int matchRule = SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE;
+            final SearchPattern annotationsPattern = SearchPattern.createPattern("org.testng.annotations.Test",
+                    IJavaSearchConstants.ANNOTATION_TYPE, IJavaSearchConstants.ANNOTATION_TYPE_REFERENCE, matchRule);
+            final SearchParticipant[] searchParticipants = new SearchParticipant[] {
+                    SearchEngine.getDefaultSearchParticipant() };
+            new SearchEngine().search(annotationsPattern, searchParticipants, scope, requestor,
+                    new SubProgressMonitor(pm, 2));
+
+            // find all classes in the region
+            for (final IType curr : candidates) {
+                if (CoreTestSearchEngine.isAccessibleClass(curr) && !Flags.isAbstract(curr.getFlags()) &&
+                        region.contains(curr)) {
+                    result.add(curr);
+                }
+            }
+        } finally {
+            pm.done();
+        }
+    }
+}
+
+/*
+     * (non-Javadoc)
+     *
+     * @see org.testng.eclipse.launch.AnnotationSearchRequestor
+     */
+class AnnotationSearchRequestor extends SearchRequestor {
+
+    private final Collection<IType> fResult;
+    private final ITypeHierarchy fHierarchy;
+
+    public AnnotationSearchRequestor(final ITypeHierarchy hierarchy, final Collection<IType> result) {
+        fHierarchy = hierarchy;
+        fResult = result;
+    }
+
+    public void acceptSearchMatch(final SearchMatch match) throws CoreException {
+        if (match.getAccuracy() == SearchMatch.A_ACCURATE && !match.isInsideDocComment()) {
+            final Object element = match.getElement();
+            if (element instanceof IType || element instanceof IMethod) {
+                final IMember member = (IMember) element;
+                final IType type = member.getElementType() == IJavaElement.TYPE ? (IType) member
+                        : member.getDeclaringType();
+                addTypeAndSubtypes(type);
+            }
+        }
+    }
+
+    private void addTypeAndSubtypes(final IType type) {
+        if (fResult.add(type)) {
+            final IType[] subclasses = fHierarchy.getSubclasses(type);
+            for (int i = 0; i < subclasses.length; i++) {
+                addTypeAndSubtypes(subclasses[i]);
+            }
+        }
     }
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/searcher/TestNGTestSearcher.java
@@ -181,8 +181,8 @@ public class TestNGTestSearcher extends BaseFrameworkSearcher {
             final TestItem item = TestItemUtils.constructTestItem(type, TestLevel.CLASS, TestKind.TestNG);
             item.setChildren(
                     Arrays.stream(type.getMethods())
-                            .map(m -> String.format("%s@%s", m.getJavaProject().getProject().getName(),
-                                    TestItemUtils.parseTestItemFullName(m, TestLevel.METHOD)))
+                            .map(m -> m.getJavaProject().getProject().getName() + "@" +
+                                    TestItemUtils.parseTestItemFullName(m, TestLevel.METHOD))
                             .collect(Collectors.toList()));
             result.put(item.getId(), item);
         }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
@@ -62,7 +62,7 @@ public class TestItemUtils {
         return new Range();
     }
 
-    private static String parseTestItemFullName(IJavaElement element, TestLevel level) {
+    public static String parseTestItemFullName(IJavaElement element, TestLevel level) {
         switch (level) {
             case CLASS:
                 final IType type = (IType) element;

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -195,7 +195,7 @@ public class TestSearchUtils {
 
         if (params.getLevel() == TestLevel.METHOD) {
             // unreachable code since the client will directly run the test when it's triggered from method level
-            return Collections.emptyList();
+            throw new UnsupportedOperationException("Method level execution is not supported at server side.");
         } else if (params.getLevel() == TestLevel.CLASS) {
             final IJavaElement[] elements = getJavaElementForSearch(params);
             if (elements == null) {

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -15,7 +15,7 @@ import com.google.gson.Gson;
 import com.microsoft.java.test.plugin.model.SearchTestItemParams;
 import com.microsoft.java.test.plugin.model.TestItem;
 import com.microsoft.java.test.plugin.model.TestLevel;
-import com.microsoft.java.test.plugin.searcher.JUnit5TestSearcher;
+import com.microsoft.java.test.plugin.searcher.TestFrameworkSearcher;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -24,7 +24,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
@@ -32,7 +31,6 @@ import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
@@ -49,7 +47,6 @@ import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchParticipant;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.SearchRequestor;
-import org.eclipse.jdt.internal.corext.refactoring.util.JavaElementUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler;
@@ -58,11 +55,14 @@ import org.eclipse.lsp4j.Location;
 
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -96,7 +96,7 @@ public class TestSearchUtils {
             return resultList;
         }
 
-        final CompilationUnit root = (CompilationUnit) parseToAst(unit, monitor);
+        final CompilationUnit root = (CompilationUnit) parseToAst(unit, true /* fromCache */, monitor);
         if (root == null) {
             return resultList;
         }
@@ -111,15 +111,19 @@ public class TestSearchUtils {
             return resultList;
         }
 
-        TestFrameworkUtils.findTestItemsInTypeBinding(binding, resultList, null /*parentClassItem*/, monitor);
+        TestFrameworkUtils.findTestItemsInTypeBinding(binding, resultList, null /* parentClassItem */, monitor);
 
         return resultList;
     }
 
-    public static ASTNode parseToAst(final ICompilationUnit unit, IProgressMonitor monitor) {
-        final CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, monitor);
-        if (astRoot != null) {
-            return astRoot;
+    public static ASTNode parseToAst(final ICompilationUnit unit, final boolean fromCache,
+            final IProgressMonitor monitor) {
+        if (fromCache) {
+            final CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES,
+                    monitor);
+            if (astRoot != null) {
+                return astRoot;
+            }
         }
 
         if (monitor.isCanceled()) {
@@ -144,7 +148,7 @@ public class TestSearchUtils {
      * @throws URISyntaxException
      * @throws JavaModelException
      */
-    public static List<TestItem> searchTestItems(List<Object> arguments, IProgressMonitor monitor)
+    public static List<TestItem> searchTestItems(final List<Object> arguments, final IProgressMonitor monitor)
             throws OperationCanceledException, InterruptedException, URISyntaxException, JavaModelException {
         final List<TestItem> resultList = new LinkedList<>();
 
@@ -162,7 +166,7 @@ public class TestSearchUtils {
                 searchInPackage(resultList, params);
                 break;
             case CLASS:
-                searchInClass(resultList, params);
+                searchInClass(resultList, params, monitor);
                 break;
             default:
                 break;
@@ -189,63 +193,66 @@ public class TestSearchUtils {
         final Gson gson = new Gson();
         final SearchTestItemParams params = gson.fromJson((String) arguments.get(0), SearchTestItemParams.class);
 
-        final IJavaSearchScope scope = createSearchScope(params);
+        if (params.getLevel() == TestLevel.METHOD) {
+            // unreachable code since the client will directly run the test when it's triggered from method level
+            return Collections.emptyList();
+        } else if (params.getLevel() == TestLevel.CLASS) {
+            final IJavaElement[] elements = getJavaElementForSearch(params);
+            if (elements == null) {
+                return Collections.emptyList();
+            }
+            final IType type = (IType) elements[0];
+            TestItem[] testItems = null;
+            if (TestFrameworkUtils.JUNIT4_TEST_SEARCHER.isTestClass(type)) {
+                testItems = TestFrameworkUtils.JUNIT4_TEST_SEARCHER.findTestsInContainer(type, monitor);
+            } else if (TestFrameworkUtils.JUNIT5_TEST_SEARCHER.isTestClass(type)) {
+                testItems = TestFrameworkUtils.JUNIT5_TEST_SEARCHER.findTestsInContainer(type, monitor);
+            } else if (TestFrameworkUtils.TESTNG_TEST_SEARCHER.isTestClass(type)) {
+                testItems = TestFrameworkUtils.TESTNG_TEST_SEARCHER.findTestsInContainer(type, monitor);
+            }
 
-        SearchPattern pattern = TestFrameworkUtils.FRAMEWORK_SEARCHERS[0].getSearchPattern();
-        for (int i = 1; i < TestFrameworkUtils.FRAMEWORK_SEARCHERS.length; i++) {
-            pattern = SearchPattern.createOrPattern(pattern,
-                    TestFrameworkUtils.FRAMEWORK_SEARCHERS[i].getSearchPattern());
-        }
+            if (testItems != null) {
+                return Arrays.asList(testItems);
+            }
 
-        final Map<String, TestItem> classMap = new HashMap<>();
-        final SearchRequestor requestor = new SearchRequestor() {
-            @Override
-            public void acceptSearchMatch(SearchMatch match) throws CoreException {
-                final Object element = match.getElement();
-                if (element instanceof IMethod) {
-                    final IMethod method = (IMethod) element;
-                    // The search result might not in the search scope.
-                    // See: https://github.com/Microsoft/vscode-java-test/issues/441
-                    if (!scope.encloses(method)) {
-                        return;
-                    }
-                    final TestItem methodItem = TestFrameworkUtils.resolveTestItemForMethod(method);
-                    if (methodItem == null) {
-                        return;
-                    }
-                    final IType type = (IType) method.getParent();
-                    final TestItem classItem = classMap.get(type.getFullyQualifiedName());
-                    if (classItem != null) {
-                        classItem.addChild(methodItem.getId());
-                    } else {
-                        final TestItem newClassItem = TestItemUtils.constructTestItem(type, TestLevel.CLASS,
-                                methodItem.getKind());
-                        newClassItem.addChild(methodItem.getId());
-                        classMap.put(type.getFullyQualifiedName(), newClassItem);
-                    }
-                } else if (element instanceof IType) {
-                    final IType type = (IType) element;
-                    if (classMap.containsKey(type.getFullyQualifiedName())) {
-                        return;
-                    }
-                    final TestItem item = TestFrameworkUtils.resolveTestItemForClass(type);
-                    if (item == null) {
-                        return;
-                    }
-                    classMap.put(type.getFullyQualifiedName(), item);
+            return Collections.emptyList();
+        } else {
+            final IJavaElement[] elements = getJavaElementForSearch(params);
+            final Map<IJavaProject, List<TestFrameworkSearcher>> javaProjectMapping = new HashMap<>();
+            final Set<IJavaProject> javaProjects = new HashSet<>();
+            for (final IJavaElement element : elements) {
+                javaProjects.add(element.getJavaProject());
+            }
+
+            final List<TestFrameworkSearcher> searchers = new LinkedList<>();
+            for (final IJavaProject javaProject : javaProjects) {
+
+                // We don't check JUnit 4 when JUnit 5 is available since it's backward compatible
+                if (javaProject.findType("org.junit.jupiter.api.Test") != null) {
+                    searchers.add(TestFrameworkUtils.JUNIT5_TEST_SEARCHER);
+                } else if (javaProject.findType("org.junit.Test") != null) {
+                    searchers.add(TestFrameworkUtils.JUNIT4_TEST_SEARCHER);
+                }
+
+                if (javaProject.findType("org.testng.annotations.Test") != null) {
+                    searchers.add(TestFrameworkUtils.TESTNG_TEST_SEARCHER);
+                }
+                javaProjectMapping.put(javaProject, searchers);
+            }
+
+            final Map<String, TestItem> map = new HashMap<>();
+            for (final IJavaElement element : elements) {
+                for (final TestFrameworkSearcher searcher : javaProjectMapping.get(element.getJavaProject())) {
+                    final TestItem[] items = searcher.findTestsInContainer(element, monitor);
+                    Arrays.stream(items).forEach(item -> {
+                        map.put(item.getId(), item);
+                    });
                 }
             }
 
-        };
-
-        try {
-            new SearchEngine().search(pattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() },
-                scope, requestor, monitor);
-        } catch (OperationCanceledException ex) {
-            // do nothing
+            return new ArrayList<>(map.values());
         }
 
-        return new ArrayList<TestItem>(classMap.values());
     }
 
     public static List<Location> searchLocation(List<Object> arguments, IProgressMonitor monitor) throws CoreException {
@@ -282,7 +289,7 @@ public class TestSearchUtils {
 
     private static boolean isInTestScope(IJavaElement element) throws JavaModelException {
         final IJavaProject project = element.getJavaProject();
-        for (final IPath sourcePath  : ProjectUtils.listSourcePaths(project)) {
+        for (final IPath sourcePath : ProjectUtils.listSourcePaths(project)) {
             if (!ProjectTestUtils.isTest(project, sourcePath)) {
                 continue;
             }
@@ -293,57 +300,33 @@ public class TestSearchUtils {
         return false;
     }
 
-    private static IJavaSearchScope createSearchScope(SearchTestItemParams params)
-            throws URISyntaxException, CoreException {
+    private static IJavaElement[] getJavaElementForSearch(SearchTestItemParams params) throws JavaModelException {
         switch (params.getLevel()) {
             case ROOT:
-                final IJavaProject[] projects = Stream.of(ProjectUtils.getJavaProjects())
+                return Stream.of(ProjectUtils.getJavaProjects())
                         .filter(javaProject -> !ProjectsManager.DEFAULT_PROJECT_NAME
                                 .equals(javaProject.getProject().getName()))
                         .toArray(IJavaProject[]::new);
-                return SearchEngine.createJavaSearchScope(projects, IJavaSearchScope.SOURCES);
             case FOLDER:
                 final Set<IJavaProject> projectSet = ProjectTestUtils.parseProjects(params.getUri());
-                return SearchEngine.createJavaSearchScope(projectSet.toArray(new IJavaElement[projectSet.size()]),
-                        IJavaSearchScope.SOURCES);
+                return projectSet.toArray(new IJavaElement[projectSet.size()]);
             case PACKAGE:
-                final IJavaElement[] elements;
                 final IJavaElement packageElement = resolvePackage(params.getUri(), params.getFullName());
-                if (params.isHierarchicalPackage()) {
-                    elements = JavaElementUtil.getPackageAndSubpackages((IPackageFragment) packageElement);
-                } else {
-                    elements = new IJavaElement[] { packageElement };
-                }
-                return SearchEngine.createJavaSearchScope(elements, IJavaSearchScope.SOURCES);
+                return new IJavaElement[] { packageElement };
             case CLASS:
                 final ICompilationUnit compilationUnit = JDTUtils.resolveCompilationUnit(params.getUri());
-                final IType[] types = compilationUnit.getAllTypes();
-                for (final IType type : types) {
-                    if (type.getFullyQualifiedName().equals(params.getFullName())) {
-                        return SearchEngine.createJavaSearchScope(new IJavaElement[] { type },
-                                IJavaSearchScope.SOURCES);
+                if (compilationUnit == null) {
+                    return null;
+                }
+                for (final IType type : compilationUnit.getAllTypes()) {
+                    if (Objects.equals(type.getFullyQualifiedName(), params.getFullName())) {
+                        return new IJavaElement[] { type };
                     }
                 }
-                break;
-            case METHOD:
-                final String fullName = params.getFullName();
-                final String className = fullName.substring(0, fullName.lastIndexOf("#"));
-                final String methodName = fullName.substring(fullName.lastIndexOf("#") + 1);
-                final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(params.getUri());
-                final IType[] allTypes = unit.getAllTypes();
-                for (final IType type : allTypes) {
-                    if (type.getFullyQualifiedName().equals(className)) {
-                        for (final IMethod method : type.getMethods()) {
-                            if (method.getElementName().equals(methodName)) {
-                                return SearchEngine.createJavaSearchScope(new IJavaElement[] { method },
-                                        IJavaSearchScope.SOURCES);
-                            }
-                        }
-                    }
-                }
+                return null;
         }
 
-        throw new RuntimeException("Cannot resolve the search scope for " + params.getFullName());
+        return new IJavaElement[] {};
     }
 
     private static void searchInFolder(List<TestItem> resultList, SearchTestItemParams params)
@@ -360,27 +343,24 @@ public class TestSearchUtils {
 
     private static void searchInPackage(List<TestItem> resultList, SearchTestItemParams params)
             throws JavaModelException {
-        final IJavaElement packageFragment = resolvePackage(params.getUri(), params.getFullName());
-        if (packageFragment == null || !(packageFragment instanceof IPackageFragment)) {
+        final IPackageFragment packageFragment = resolvePackage(params.getUri(), params.getFullName());
+        if (packageFragment == null) {
             return;
         }
 
-        for (final ICompilationUnit unit : ((IPackageFragment) packageFragment).getCompilationUnits()) {
+        for (final ICompilationUnit unit : packageFragment.getCompilationUnits()) {
             for (final IType type : unit.getTypes()) {
                 resultList.add(TestItemUtils.constructTestItem(type, TestLevel.CLASS));
             }
         }
     }
 
-    private static IJavaElement resolvePackage(String uriString, String fullName) throws JavaModelException {
-        final IFolder resource = (IFolder) JDTUtils.findResource(JDTUtils.toURI(uriString),
+    private static IPackageFragment resolvePackage(String uriString, String fullName) throws JavaModelException {
+        if (TestItemUtils.DEFAULT_PACKAGE_NAME.equals(fullName)) {
+            final IFolder resource = (IFolder) JDTUtils.findResource(JDTUtils.toURI(uriString),
                     ResourcesPlugin.getWorkspace().getRoot()::findContainersForLocationURI);
-        final IJavaElement element = JavaCore.create(resource);
-        if (element == null) {
-            return null;
-        }
-        if (element instanceof IPackageFragmentRoot) {
-            if (TestItemUtils.DEFAULT_PACKAGE_NAME.equals(fullName)) {
+            final IJavaElement element = JavaCore.create(resource);
+            if (element instanceof IPackageFragmentRoot) {
                 final IPackageFragmentRoot packageRoot = (IPackageFragmentRoot) element;
                 for (final IJavaElement child : packageRoot.getChildren()) {
                     if (child instanceof IPackageFragment && ((IPackageFragment) child).isDefaultPackage()) {
@@ -388,82 +368,38 @@ public class TestSearchUtils {
                     }
                 }
             }
+        } else {
+            return JDTUtils.resolvePackage(uriString);
         }
 
-        return element;
+        return null;
     }
 
-    private static void searchInClass(List<TestItem> resultList, SearchTestItemParams params)
-            throws JavaModelException {
+    private static void searchInClass(List<TestItem> resultList, SearchTestItemParams params,
+            IProgressMonitor monitor) throws JavaModelException {
         final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(params.getUri());
+        final CompilationUnit root = (CompilationUnit) parseToAst(unit, false /* fromCache */, monitor);
         for (final IType type : unit.getAllTypes()) {
             if (type.getFullyQualifiedName().equals(params.getFullName())) {
+                final ASTNode node = root.findDeclaringNode(type.getKey());
+                if (!(node instanceof TypeDeclaration)) {
+                    continue;
+                }
+
+                final ITypeBinding binding = ((TypeDeclaration) node).resolveBinding();
+                if (binding == null) {
+                    continue;
+                }
+
+                TestFrameworkUtils.findTestItemsInTypeBinding(binding, resultList, null /* parentClassItem */, monitor);
+                resultList.removeIf(item -> item.getLevel() != TestLevel.METHOD ||
+                        !item.getFullName().startsWith(params.getFullName() + "#"));
                 for (final IType innerType : type.getTypes()) {
                     resultList.add(TestItemUtils.constructTestItem(innerType, TestLevel.CLASS));
                 }
-
-                if (!isTestableClass(type)) {
-                    continue;
-                }
-                for (final IMethod method : type.getMethods()) {
-                    final TestItem item = TestFrameworkUtils.resolveTestItemForMethod(method);
-                    if (item != null) {
-                        resultList.add(item);
-                    }
-                }
+                break;
             }
         }
-    }
-
-    private static boolean isTestableClass(IType type) throws JavaModelException {
-        final int flags = type.getFlags();
-        if (Flags.isInterface(flags) || Flags.isAbstract(flags)) {
-            return false;
-        }
-
-        final IJavaElement parent = type.getParent();
-
-        if (parent instanceof ITypeRoot) {
-            return true;
-        }
-
-        if (!(parent instanceof IType)) {
-            return false;
-        }
-
-        if (isJunit5TestableClass(type)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    private static boolean isJunit5TestableClass(IType type) throws JavaModelException {
-        final int flags = type.getFlags();
-
-        // Classes with Testable annotation are testable
-        if (TestFrameworkUtils.hasAnnotation(
-                type,
-                JUnit5TestSearcher.JUNIT_PLATFORM_TESTABLE,
-                true /*checkHierarchy*/
-        )) {
-            return true;
-        }
-
-        // Jupiter's Nested annotation does not have Testable as meta annotation
-        if (TestFrameworkUtils.hasAnnotation(type, JUnit5TestSearcher.JUPITER_NESTED, true /*checkHierarchy*/) ||
-                (Flags.isStatic(flags) && Flags.isPublic(flags))) {
-            return true;
-        }
-
-        // Classes whose inner classes are testable should also be testable
-        for (final IJavaElement child : type.getChildren())  {
-            if (child instanceof IType && isJunit5TestableClass((IType) child)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static boolean isJavaElementExist(IJavaElement element) {


### PR DESCRIPTION
This PR leverage the upstream Test Finder for test discovery.

The previous implementation used `SearchEngine`, since it's not good at handleing meta annotation, some bugs are introduced.

fix #641
fix #773
fix #818