### PR TITLE
fix: Cannot navigate to source for JUnit4 parameterized tests

### DIFF
--- a/src/commands/testReportCommands.ts
+++ b/src/commands/testReportCommands.ts
@@ -39,7 +39,7 @@ export async function openTestSourceLocation(uri: string, range: string, fullNam
     if (uri && range) {
         return commands.executeCommand(JavaTestRunnerCommands.OPEN_DOCUMENT, Uri.parse(uri), JSON.parse(range) as Range);
     } else if (fullName) {
-        const items: ILocation[] = await searchTestLocation(fullName.slice(fullName.indexOf('@') + 1));
+        const items: ILocation[] = await searchTestLocation(fullName.slice(fullName.indexOf('@') + 1, fullName.indexOf('[')));
         if (items.length === 1) {
             return commands.executeCommand(JavaTestRunnerCommands.OPEN_DOCUMENT, Uri.parse(items[0].uri), items[0].range);
         } else if (items.length > 1) {


### PR DESCRIPTION
fix #1134 