### PR TITLE
fix: Add static modifier for Junit 4 & 5's Before/AfterClass methods

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestGenerationUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestGenerationUtils.java
@@ -367,6 +367,7 @@ public class TestGenerationUtils {
             return false;
         }
 
+        annotation = annotation.substring(annotation.lastIndexOf(".") + 1);
         if (kind == TestKind.JUnit) {
             switch (annotation) {
                 case JUNIT4_BEFORE_CLASS_ANNOTATION:


### PR DESCRIPTION
Fix a regression.

The JUnit 4 & 5's BeforeClass and AfterClass method should be static.