### PR TITLE
fix: Can queue the running tests

### DIFF
--- a/src/runners/baseRunner/BaseRunner.ts
+++ b/src/runners/baseRunner/BaseRunner.ts
@@ -70,7 +70,7 @@ export abstract class BaseRunner implements ITestRunner {
             return;
         }
         return await debug.startDebugging(this.testContext.workspaceFolder, launchConfiguration).then(async (success: boolean) => {
-            if (!success) {
+            if (!success || token.isCancellationRequested) {
                 this.tearDown();
                 return;
             }

--- a/src/utils/launchUtils.ts
+++ b/src/utils/launchUtils.ts
@@ -34,7 +34,7 @@ export async function resolveLaunchConfigurationForRunner(runner: BaseRunner, te
 
     if (testContext.kind === TestKind.TestNG) {
         return {
-            name: 'Launch Java Tests',
+            name: `Launch Java Tests - ${testContext.testItems[0].label}`,
             type: 'java',
             request: 'launch',
             mainClass: 'com.microsoft.java.test.runner.Launcher',
@@ -55,7 +55,7 @@ export async function resolveLaunchConfigurationForRunner(runner: BaseRunner, te
     }
 
     return {
-        name: 'Launch Java Tests',
+        name: `Launch Java Tests - ${testContext.testItems[0].label}`,
         type: 'java',
         request: 'launch',
         mainClass: launchArguments.mainClass,


### PR DESCRIPTION
We use the launch configuration name to identify if a debug session is end and to do the clean up work.

Previously, since the launch configuration name is staticly same, that causes the test sessions cannot be queued. (All the session names are same)