### PR TITLE
fix: Cannot run PDE tests

### DIFF
--- a/src/commands/testExplorerCommands.ts
+++ b/src/commands/testExplorerCommands.ts
@@ -18,7 +18,7 @@ export async function runTestsFromTestExplorer(testItem: TestItem, launchConfigu
     do {
         pathToRoot.push(testItem.id);
         testItem = testItem.parent!;
-    } while (testItem.parent);
+    } while (testItem);
     let currentItem: TestItem | undefined = testController?.items.get(pathToRoot.pop()!);
     if (!currentItem) {
         return;


### PR DESCRIPTION
Previously in the proposed API, the root item still have an implicit parent. But in the stable release, the implicit parent is removed and become undefined.

So in the while check, we can just check the item itself.