### PR TITLE
fix: Failed to create test item when test controller is not initialized

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,9 +6,9 @@ const cp = require('child_process');
 const tslint = require('gulp-tslint');
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 
 const serverDir = path.join(__dirname, 'java-extension');
-const resourceDir = path.join(__dirname, 'resources');
 
 // Build required jar files.
 gulp.task('build-plugin', (done) => {
@@ -77,6 +77,7 @@ function updateVersion() {
         });
 
         fs.writeFileSync('./package.json', JSON.stringify(packageJsonData, null, 4));
+        fs.appendFileSync('./package.json', os.EOL);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,7 +100,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.DEBUG_TEST_FROM_JAVA_PROJECT_EXPLORER, async (node: any) => await runTestsFromJavaProjectExplorer(node, true /* isDebug */)),
         window.onDidChangeActiveTextEditor(async (e: TextEditor | undefined) => {
             if (e?.document) {
-                if (!isJavaFile(e.document)) {
+                if (!isJavaFile(e.document) || !isStandardServerReady()) {
                     return;
                 }
 
@@ -111,9 +111,10 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
             }
         }),
         workspace.onDidChangeTextDocument(async (e: TextDocumentChangeEvent) => {
-            if (!isJavaFile(e.document)) {
+            if (!isJavaFile(e.document) || !isStandardServerReady()) {
                 return;
             }
+
             if (!await testSourceProvider.isOnTestSourcePath(e.document.uri)) {
                 return;
             }
@@ -135,9 +136,9 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
     if (isStandardServerReady()) {
         registerTestCodeActionProvider();
         createTestController();
+        await showTestItemsInCurrentFile();
     }
 
-    await showTestItemsInCurrentFile();
 }
 
 async function showTestItemsInCurrentFile(): Promise<void> {


### PR DESCRIPTION
fix #1269

Should call JLS only when its ready