### PR TITLE
fix: Performance regression when resolving launch arguments

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfiguration.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfiguration.java
@@ -75,6 +75,9 @@ class JUnitLaunchConfigurationInfo extends LaunchConfigurationInfo {
     public JUnitLaunchConfigurationInfo(TestInfo testInfo) throws CoreException {
         try {
             final StrSubstitutor sub = new StrSubstitutor(testInfo.toValueMap());
+            // here we just simply set the mainType (which is a fake configuration), the purpose is to leverage
+            // JUnitLaunchConfiguration to get the classpath/modulepath, the real parameter will be resolved in
+            // JUnitLaunchConfigurationDelegate.parseParameters() separately.
             final String launchXml = sub.replace(JUnitLaunchConfigurationTemplate.JUNIT_TEMPLATE);
             final DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             parser.setErrorHandler(new DefaultHandler());
@@ -89,15 +92,14 @@ class JUnitLaunchConfigurationInfo extends LaunchConfigurationInfo {
 }
 
 class TestInfo {
-    public String testContainer = "";
     public String testKind = "";
-    public String[] testNames;
+    public String mainType = "";
     public IProject project;
 
     public Map<String, String> toValueMap() {
         final Map<String, String> valueMap = new HashMap<>();
-        valueMap.put("testContainer", testContainer);
         valueMap.put("testKind", testKind);
+        valueMap.put("mainType", mainType);
         return valueMap;
     }
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationTemplate.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationTemplate.java
@@ -20,9 +20,7 @@ public class JUnitLaunchConfigurationTemplate {
           "</listAttribute>\n" +
           "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_TYPES\">\n" +
           "</listAttribute>\n" +
-          "<stringAttribute key=\"org.eclipse.jdt.junit.CONTAINER\" value=\"${testContainer}\"/>\n" +
           "<booleanAttribute key=\"org.eclipse.jdt.junit.KEEPRUNNING_ATTR\" value=\"false\"/>\n" +
-          "<stringAttribute key=\"org.eclipse.jdt.junit.TESTNAME\" value=\"${testName}\"/>\n" +
           "<stringAttribute key=\"org.eclipse.jdt.junit.TEST_KIND\" value=\"${testKind}\"/>\n" +
           "<stringAttribute key=\"org.eclipse.jdt.launching.MAIN_TYPE\" value=\"${mainType}\"/>\n" +
           "<stringAttribute key=\"org.eclipse.jdt.launching.VM_ARGUMENTS\" value=\"-ea\"/>\n" +

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchUtils.java
@@ -17,7 +17,7 @@ import com.microsoft.java.test.plugin.model.TestKind;
 import com.microsoft.java.test.plugin.model.TestLevel;
 import com.microsoft.java.test.plugin.util.JUnitPlugin;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -26,6 +26,7 @@ import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
@@ -73,7 +74,14 @@ public class JUnitLaunchUtils {
             throw new RuntimeException("Failed to get the project: " + args.projectName);
         }
         info.project = javaProject.getProject();
-        info.testContainer = StringEscapeUtils.escapeXml(javaProject.getHandleIdentifier());
+        if (ArrayUtils.isNotEmpty(args.testNames)) {
+            if (args.testLevel == TestLevel.CLASS) {
+                info.mainType = args.testNames[0].substring(args.testNames[0].indexOf("@") + 1);
+            } else if (args.testLevel == TestLevel.METHOD) {
+                final IMethod method = (IMethod) JavaCore.create(args.testNames[0]);
+                info.mainType = method.getDeclaringType().getFullyQualifiedName();
+            }
+        }
 
         final ILaunchConfiguration configuration = new JUnitLaunchConfiguration("JUnit Launch Configuration", info);
         final JUnitLaunchConfigurationDelegate delegate = new JUnitLaunchConfigurationDelegate(args);


### PR DESCRIPTION
fix #1273 

Simply pass a `mainType` to the launch configuration to let upstream resolve the classpath/modulepath quickly.

Before this change, we just set the container, which will invoke a lot of computation on type hierarchy