### PR TITLE
fix: Use the customized refresh test explorer command

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,7 +33,6 @@ export namespace JavaTestRunnerCommands {
 export namespace VSCodeCommands {
     export const RUN_TESTS_IN_CURRENT_FILE: string = 'testing.runCurrentFile';
     export const DEBUG_TESTS_IN_CURRENT_FILE: string = 'testing.debugCurrentFile';
-    export const REFRESH_TESTS: string = 'testing.refreshTests';
 }
 
 export namespace Configurations {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
             const onDidClasspathUpdate: Event<Uri> = extensionApi.onDidClasspathUpdate;
             context.subscriptions.push(onDidClasspathUpdate(async () => {
                 testSourceProvider.clear();
-                commands.executeCommand(VSCodeCommands.REFRESH_TESTS);
+                commands.executeCommand(JavaTestRunnerCommands.REFRESH_TEST_EXPLORER);
             }));
         }
 
@@ -74,7 +74,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
             const onDidProjectsImport: Event<Uri[]> = extensionApi.onDidProjectsImport;
             context.subscriptions.push(onDidProjectsImport(async () => {
                 testSourceProvider.clear();
-                commands.executeCommand(VSCodeCommands.REFRESH_TESTS);
+                commands.executeCommand(JavaTestRunnerCommands.REFRESH_TEST_EXPLORER);
             }));
         }
     }


### PR DESCRIPTION
`testing.refreshTests` has been removed in VS Code so we need to use the extension customized one

fix #1298