### PR TITLE
#878 Fix some 'Failed to get workspace folder' error conditions.

### DIFF
--- a/src/controller/testController.ts
+++ b/src/controller/testController.ts
@@ -195,8 +195,10 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
                             return resolve();
                         });
                         option.progressReporter?.report('Resolving launch configuration...');
+                        // This normalization fixes issues with upper case vs. lower case drive letters on Windows. See #878.
+                        const uri = items[0].uri?.fsPath? Uri.file(items[0].uri?.fsPath!) : items[0].uri!;
                         // TODO: improve the config experience
-                        const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(items[0].uri!);
+                        const workspaceFolder: WorkspaceFolder | undefined = workspace.getWorkspaceFolder(uri);
                         if (!workspaceFolder) {
                             window.showErrorMessage(`Failed to get workspace folder from test item: ${items[0].label}.`);
                             continue;


### PR DESCRIPTION
This fixes my instance of the #878 error. Also the bug is closed it still ocures in my environment. I've described my problem there in comment https://github.com/microsoft/vscode-java-test/issues/878#issuecomment-938396359.

As the bug is already closed I'm not sure if someone will notice my comments there. I also did not want to open another bug.