### PR TITLE
chore: Migrate to Java 11

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/META-INF/MANIFEST.MF
+++ b/java-extension/com.microsoft.java.test.plugin/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: com.microsoft.java.test.plugin
 Bundle-SymbolicName: com.microsoft.java.test.plugin;singleton:=true
 Bundle-Version: 0.33.1
 Bundle-Activator: com.microsoft.java.test.plugin.util.JUnitPlugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.jdt.core,
  org.eclipse.jdt.launching,
  org.osgi.framework;version="1.3.0"

--- a/java-extension/com.microsoft.java.test.plugin/target.target
+++ b/java-extension/com.microsoft.java.test.plugin/target.target
@@ -18,7 +18,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.5.0.201805160042"/>
-            <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.0-2018-05-16_00-46-30-H11"/>
+            <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="com.ibm.icu.base" version="58.2.0.v20170418-1837"/>

--- a/java-extension/pom.xml
+++ b/java-extension/pom.xml
@@ -65,11 +65,6 @@
             </snapshots>
         </repository>
         <repository>
-            <id>LSP4J</id>
-            <layout>p2</layout>
-            <url>https://download.eclipse.org/lsp4j/updates/releases/0.8.0/</url>
-        </repository>
-        <repository>
             <id>JDT.LS</id>
             <layout>p2</layout>
             <url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
@@ -77,7 +72,7 @@
         <repository>
             <id>JBOSS.TOOLS</id>
             <layout>p2</layout>
-            <url>https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.0-2018-05-16_00-46-30-H11</url>
+            <url>https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22</url>
         </repository>
         <repository>
             <id>orbit</id>


### PR DESCRIPTION
Now that the Java Language Support Extension has embedded JRE 17 to run all Java extensions, it's time to migrate to Java 11.

Signed-off-by: Sheng Chen <sheche@microsoft.com>