### PR TITLE
fix: Should recognize test classes with '$' in their names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - The `@Test` method will be selected by default when using `Generating Tests...` source action. [#1350](https://github.com/microsoft/vscode-java-test/issues/1350)
 
+### Fixed
+- [Bugs fixed](https://github.com/microsoft/vscode-java-test/issues?q=is%3Aissue+is%3Aclosed+label%3Abug+milestone%3A0.34.0)
+
 ## 0.33.1
 ### Fixed
 - Reduce the line spacing in test messages [PR#1345](https://github.com/microsoft/vscode-java-test/pull/1345)

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestSearchUtils.java
@@ -48,6 +48,7 @@ import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.TypeNameMatch;
 import org.eclipse.jdt.core.search.TypeNameMatchRequestor;
+import org.eclipse.jdt.internal.corext.refactoring.structure.ASTNodeSearchUtil;
 import org.eclipse.jdt.internal.junit.util.CoreTestSearchEngine;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
@@ -271,12 +272,12 @@ public class TestSearchUtils {
                 continue;
             }
 
-            final ASTNode node = root.findDeclaringNode(type.getKey());
-            if (!(node instanceof TypeDeclaration)) {
+            final TypeDeclaration typeDeclaration = ASTNodeSearchUtil.getTypeDeclarationNode(type, root);
+            if (typeDeclaration == null) {
                 continue;
             }
 
-            final ITypeBinding binding = ((TypeDeclaration) node).resolveBinding();
+            final ITypeBinding binding = typeDeclaration.resolveBinding();
             if (binding == null) {
                 continue;
             }
@@ -344,12 +345,12 @@ public class TestSearchUtils {
             Collections.emptyList();
         }
 
-        final ASTNode node = root.findDeclaringNode(primaryType.getKey());
-        if (!(node instanceof TypeDeclaration)) {
+        final TypeDeclaration typeDeclaration = ASTNodeSearchUtil.getTypeDeclarationNode(primaryType, root);
+        if (typeDeclaration == null) {
             return Collections.emptyList();
         }
 
-        final ITypeBinding binding = ((TypeDeclaration) node).resolveBinding();
+        final ITypeBinding binding = typeDeclaration.resolveBinding();
         if (binding == null) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
fix #1364.

According to the API document, `CompilationUnit.findDeclaringNode()` will return null when:

- if the corresponding node cannot be determined.
- if bindings were not requested when this AST was built.

While `ASTNodeSearchUtil` works in this case.

> Note: there are other usages for `CompilationUnit.findDeclaringNode()`, will consider if they should also be replaced to `ASTNodeSearchUtil`.

Signed-off-by: sheche <sheche@microsoft.com>