### PR TITLE
fix: Generate '_' instead of '$' for inner class

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestGenerationUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestGenerationUtils.java
@@ -408,8 +408,8 @@ public class TestGenerationUtils {
 
     private static String getDefaultTestFullyQualifiedName(ITypeBinding typeBinding, IJavaProject project,
             IClasspathEntry testEntry) throws JavaModelException {
-        final String defaultName = typeBinding.getBinaryName() + "Test";
-        final String attemptName = typeBinding.getBinaryName() + "Tests";
+        final String defaultName = getClassName(typeBinding) + "Test";
+        final String attemptName = getClassName(typeBinding) + "Tests";
         try {
             ICompilationUnit testCompilationUnit = getTestCompilationUnit(project, testEntry, attemptName);
             if (testCompilationUnit.exists()) {
@@ -442,6 +442,17 @@ public class TestGenerationUtils {
         }
 
         return defaultName;
+    }
+
+    private static String getClassName(ITypeBinding typeBinding) {
+        final String qualifiedName = typeBinding.getQualifiedName();
+        final String packageName = typeBinding.getPackage().getName();
+        if (packageName.isEmpty()) {
+            return qualifiedName.replace(".", "_");
+        } else {
+            final String typeName = qualifiedName.substring(packageName.length() + 1);
+            return packageName + "." + typeName.replace(".", "_");
+        }
     }
 
     private static ICompilationUnit getTestCompilationUnit(IJavaProject javaProject, IClasspathEntry testEntry,

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestGenerationUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestGenerationUtils.java
@@ -444,14 +444,20 @@ public class TestGenerationUtils {
         return defaultName;
     }
 
+    /**
+     * Replace the '$' in the type name to '_'.
+     * See: https://github.com/microsoft/vscode-java-test/issues/1367
+     * @param typeBinding type binding
+     * @return the class name
+     */
     private static String getClassName(ITypeBinding typeBinding) {
-        final String qualifiedName = typeBinding.getQualifiedName();
+        final String binaryName = typeBinding.getBinaryName();
         final String packageName = typeBinding.getPackage().getName();
         if (packageName.isEmpty()) {
-            return qualifiedName.replace(".", "_");
+            return binaryName.replace("$", "_");
         } else {
-            final String typeName = qualifiedName.substring(packageName.length() + 1);
-            return packageName + "." + typeName.replace(".", "_");
+            final String typeName = binaryName.substring(packageName.length() + 1);
+            return packageName + "." + typeName.replace("$", "_");
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,9 +136,9 @@
             "dev": true
         },
         "@types/eslint": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.2.2.tgz",
-            "integrity": "sha512-nQxgB8/Sg+QKhnV8e0WzPpxjIGT3tuJDDzybkDi8ItE/IgTlHo07U0shaIjzhcvQxlq9SDRE42lsJ23uvEgJ2A==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+            "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -389,24 +389,24 @@
             }
         },
         "@webpack-cli/configtest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-            "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+            "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
             "dev": true
         },
         "@webpack-cli/info": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-            "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+            "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
             "dev": true,
             "requires": {
                 "envinfo": "^7.7.3"
             }
         },
         "@webpack-cli/serve": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-            "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+            "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
             "dev": true
         },
         "@xtuc/ieee754": {
@@ -608,9 +608,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001299",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
-            "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
+            "version": "1.0.30001301",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
+            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
             "dev": true
         },
         "chainsaw": {
@@ -644,9 +644,9 @@
             }
         },
         "chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
             "requires": {
                 "anymatch": "~3.1.2",
@@ -776,9 +776,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.43",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.43.tgz",
-            "integrity": "sha512-PO3kEfcxPrti/4STbXvCkNIF4fgWvCKl2508e6UI7KomCDffpIfeBZLXsh5DK/XGsjUw3kwq6WEsi0MJTlGAdg==",
+            "version": "1.4.52",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.52.tgz",
+            "integrity": "sha512-JGkh8HEh5PnVrhU4HbpyyO0O791dVY6k7AdqfDeqbcRMeoGxtNHWT77deR2nhvbLe4dKpxjlDEvdEwrvRLGu2Q==",
             "dev": true
         },
         "emoji-regex": {
@@ -1378,49 +1378,52 @@
             }
         },
         "mocha": {
-            "version": "9.1.4",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.4.tgz",
-            "integrity": "sha512-+q2aV5VlJZuLgCWoBvGI5zEwPF9eEI0kr/sAA9Jm4xMND7RfIEyF8JE7C0JIg8WXRG+P1sdIAb5ccoHPlXLzcw==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
+            "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.2",
-                "debug": "4.3.2",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.7",
+                "glob": "7.2.0",
                 "growl": "1.10.5",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
                 "minimatch": "3.0.4",
                 "ms": "2.1.3",
-                "nanoid": "3.1.25",
+                "nanoid": "3.2.0",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
-                "workerpool": "6.1.5",
+                "workerpool": "6.2.0",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
             },
             "dependencies": {
-                "glob": {
-                    "version": "7.1.7",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-                    "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "ms": "2.1.2"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                            "dev": true
+                        }
                     }
                 }
             }
@@ -1432,9 +1435,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-            "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
             "dev": true
         },
         "neo-async": {
@@ -2137,9 +2140,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true
         },
         "universalify": {
@@ -2260,9 +2263,9 @@
             }
         },
         "webpack": {
-            "version": "5.66.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.66.0.tgz",
-            "integrity": "sha512-NJNtGT7IKpGzdW7Iwpn/09OXz9inIkeIQ/ibY6B+MdV1x6+uReqz/5z1L89ezWnpPDWpXF0TY5PCYKQdWVn8Vg==",
+            "version": "5.67.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.67.0.tgz",
+            "integrity": "sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
@@ -2288,7 +2291,7 @@
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.3.1",
-                "webpack-sources": "^3.2.2"
+                "webpack-sources": "^3.2.3"
             },
             "dependencies": {
                 "graceful-fs": {
@@ -2300,15 +2303,15 @@
             }
         },
         "webpack-cli": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-            "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
+            "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
             "dev": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.1.0",
-                "@webpack-cli/info": "^1.4.0",
-                "@webpack-cli/serve": "^1.6.0",
+                "@webpack-cli/configtest": "^1.1.1",
+                "@webpack-cli/info": "^1.4.1",
+                "@webpack-cli/serve": "^1.6.1",
                 "colorette": "^2.0.14",
                 "commander": "^7.0.0",
                 "execa": "^5.0.0",
@@ -2359,9 +2362,9 @@
             "dev": true
         },
         "workerpool": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-            "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+            "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
             "dev": true
         },
         "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -421,14 +421,14 @@
         "@types/sinon": "^10.0.8",
         "@types/vscode": "1.63.0",
         "glob": "^7.2.0",
-        "mocha": "^9.1.4",
+        "mocha": "^9.2.0",
         "sinon": "^11.1.2",
         "ts-loader": "^9.2.6",
         "tslint": "^6.1.3",
-        "typescript": "^4.5.4",
+        "typescript": "^4.5.5",
         "vscode-test": "^1.6.1",
-        "webpack": "^5.66.0",
-        "webpack-cli": "^4.9.1"
+        "webpack": "^5.67.0",
+        "webpack-cli": "^4.9.2"
     },
     "dependencies": {
         "fs-extra": "^7.0.1",


### PR DESCRIPTION
- The upstream runner could not fine tests when '$' is in class name,
  so we use '_' when generating test classes.

Signed-off-by: sheche <sheche@microsoft.com>

// see discussion in #1367 