### PR TITLE
fix: Find the location of inherited test methods

### DIFF
--- a/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
+++ b/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
@@ -285,7 +285,10 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
                 if (this.testContext.kind === TestKind.JUnit) {
                     // change test[0] -> test
                     // to fix: https://github.com/microsoft/vscode-java-test/issues/1296
-                    id = id.substring(0, id.lastIndexOf('['));
+                    const indexOfParameterizedTest: number = id.lastIndexOf('[');
+                    if (indexOfParameterizedTest > -1) {
+                        id = id.substring(0, id.lastIndexOf('['));
+                    }
                 }
             }
             const location: Location | undefined = await findTestLocation(id);

--- a/test/suite/navigation.test.ts
+++ b/test/suite/navigation.test.ts
@@ -5,9 +5,10 @@
 
 import * as assert from 'assert';
 import * as path from 'path';
-import { Uri, window } from 'vscode';
+import { Location, Uri, window } from 'vscode';
 import { ITestNavigationResult } from '../../src/commands/navigation/navigationCommands';
 import { JavaTestRunnerDelegateCommands } from '../../src/constants';
+import { findTestLocation } from '../../src/runners/utils';
 import { executeJavaLanguageServerCommand } from '../../src/utils/commandUtils';
 import { setupTestEnv } from "./utils";
 
@@ -40,5 +41,10 @@ suite('Test Navigation Tests', () => {
         assert.strictEqual(searchResult?.items.length, 1);
         assert.strictEqual(searchResult?.items[0].simpleName, 'App');
         assert.strictEqual(searchResult?.items[0].fullyQualifiedName, 'junit.App');
+    });
+
+    test('test find inherited test method location', async () => {
+        const location: Location | undefined = await findTestLocation("junit@junit4.ExtendedTest#test");
+        assert.ok(location?.uri.fsPath.endsWith("BaseTest.java"));
     });
 });

--- a/test/test-projects/junit/src/test/java/junit4/BaseTest.java
+++ b/test/test-projects/junit/src/test/java/junit4/BaseTest.java
@@ -1,0 +1,9 @@
+package junit4;
+
+import org.junit.Test;
+
+public class BaseTest {
+	@Test
+	public void test() {
+	}
+}

--- a/test/test-projects/junit/src/test/java/junit4/ExtendedTest.java
+++ b/test/test-projects/junit/src/test/java/junit4/ExtendedTest.java
@@ -1,0 +1,9 @@
+package junit4;
+
+import org.junit.Test;
+
+public class ExtendedTest extends BaseTest {
+	@Test
+	public void extendedTest() {
+	}
+}


### PR DESCRIPTION
- When append test messages, keep finding the test method from current type to all of its supertype.

Signed-off-by: sheche <sheche@microsoft.com>