### PR TITLE
fix: Remove the refresh Java tests command

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,11 +162,6 @@
                 "command": "java.test.editor.debug",
                 "title": "%contributes.commands.java.test.editor.debug.title%",
                 "category": "Java"
-            },
-            {
-                "command": "java.test.refreshExplorer",
-                "title": "%contributes.commands.java.test.refreshExplorer.title%",
-                "category": "Java"
             }
         ],
         "configuration": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,7 +4,6 @@
     "contributes.commands.java.test.editor.debug.title": "Debug Tests",
     "contributes.commands.java.test.runFromJavaProjectExplorer.title": "Run Tests",
     "contributes.commands.java.test.debugFromJavaProjectExplorer.title": "Debug Tests",
-    "contributes.commands.java.test.refreshExplorer.title": "Refresh Tests",
     "contributes.commands.java.test.goToTest.title": "Go to Test",
     "contributes.commands.java.test.goToTestSubject.title": "Go to Test Subject",
     "configuration.java.test.defaultConfig.description": "Specify the name of the default test configuration",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -4,7 +4,6 @@
     "contributes.commands.java.test.editor.debug.title": "调试测试用例",
     "contributes.commands.java.test.runFromJavaProjectExplorer.title": "运行测试",
     "contributes.commands.java.test.debugFromJavaProjectExplorer.title": "调试测试",
-    "contributes.commands.java.test.refreshExplorer.title": "刷新测试",
     "contributes.commands.java.test.goToTest.title": "转到测试",
     "contributes.commands.java.test.goToTestSubject.title": "转到被测试代码",
     "configuration.java.test.defaultConfig.description": "设定默认测试配置项的名称",

--- a/src/commands/testExplorerCommands.ts
+++ b/src/commands/testExplorerCommands.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { DebugConfiguration, TestItem, TestRunRequest } from 'vscode';
+import { sendInfo } from 'vscode-extension-telemetry-wrapper';
 import { runTests, testController } from '../controller/testController';
 import { loadJavaProjects } from '../controller/utils';
 import { showTestItemsInCurrentFile } from '../extension';
@@ -36,7 +37,8 @@ export async function runTestsFromTestExplorer(testItem: TestItem, launchConfigu
     await runTests(request, { launchConfiguration, isDebug });
 }
 
-export async function refresh(): Promise<void> {
+export async function refreshExplorer(): Promise<void> {
+    sendInfo("", { refreshJavaTest: 1 });
     testController?.items.forEach((root: TestItem) => {
         testController?.items.delete(root.id);
     });

--- a/src/commands/testExplorerCommands.ts
+++ b/src/commands/testExplorerCommands.ts
@@ -38,7 +38,7 @@ export async function runTestsFromTestExplorer(testItem: TestItem, launchConfigu
 }
 
 export async function refreshExplorer(): Promise<void> {
-    sendInfo('', { refreshJavaTest: 1 });
+    sendInfo('', { name: 'refreshTests' });
     testController?.items.forEach((root: TestItem) => {
         testController?.items.delete(root.id);
     });

--- a/src/commands/testExplorerCommands.ts
+++ b/src/commands/testExplorerCommands.ts
@@ -38,7 +38,7 @@ export async function runTestsFromTestExplorer(testItem: TestItem, launchConfigu
 }
 
 export async function refreshExplorer(): Promise<void> {
-    sendInfo("", { refreshJavaTest: 1 });
+    sendInfo('', { refreshJavaTest: 1 });
     testController?.items.forEach((root: TestItem) => {
         testController?.items.delete(root.id);
     });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,6 @@ export namespace JavaTestRunnerCommands {
     export const DEBUG_TEST_FROM_JAVA_PROJECT_EXPLORER: string = 'java.test.debugFromJavaProjectExplorer';
     export const RUN_FROM_TEST_EXPLORER: string = 'java.test.explorer.run';
     export const DEBUG_FROM_TEST_EXPLORER: string = 'java.test.explorer.debug';
-    export const REFRESH_TEST_EXPLORER: string = 'java.test.refreshExplorer';
     export const JAVA_TEST_GENERATE_TESTS: string = 'java.test.generateTests';
     export const FIND_TEST_LOCATION: string = 'vscode.java.test.findTestLocation';
     export const GO_TO_TEST: string = 'java.test.goToTest';

--- a/src/controller/testController.ts
+++ b/src/controller/testController.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT license.
 
 import * as _ from 'lodash';
-import { CancellationToken, commands, DebugConfiguration, Disposable, FileSystemWatcher, RelativePattern, TestController, TestItem, TestRun, TestRunProfileKind, TestRunRequest, tests, TestTag, Uri, window, workspace, WorkspaceFolder } from 'vscode';
+import { CancellationToken, DebugConfiguration, Disposable, FileSystemWatcher, RelativePattern, TestController, TestItem, TestRun, TestRunProfileKind, TestRunRequest, tests, TestTag, Uri, window, workspace, WorkspaceFolder } from 'vscode';
 import { instrumentOperation, sendError, sendInfo } from 'vscode-extension-telemetry-wrapper';
-import { INVOCATION_PREFIX, JavaTestRunnerCommands } from '../constants';
+import { refreshExplorer } from '../commands/testExplorerCommands';
+import { INVOCATION_PREFIX } from '../constants';
 import { IProgressReporter } from '../debugger.api';
 import { isStandardServerReady, progressProvider } from '../extension';
 import { testSourceProvider } from '../provider/testSourceProvider';
@@ -37,7 +38,7 @@ export function createTestController(): void {
     testController.createRunProfile('Debug Tests', TestRunProfileKind.Debug, runHandler, true, runnableTag);
 
     testController.refreshHandler = () => {
-        commands.executeCommand(JavaTestRunnerCommands.REFRESH_TEST_EXPLORER);
+        refreshExplorer();
     }
 
     startWatchingWorkspace();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentO
 import { navigateToTestOrTarget } from './commands/navigation/navigationCommands';
 import { generateTests } from './commands/generationCommands';
 import { runTestsFromJavaProjectExplorer } from './commands/projectExplorerCommands';
-import { refresh, runTestsFromTestExplorer } from './commands/testExplorerCommands';
+import { refreshExplorer, runTestsFromTestExplorer } from './commands/testExplorerCommands';
 import { openStackTrace } from './commands/testReportCommands';
 import { Context, ExtensionName, JavaTestRunnerCommands, VSCodeCommands } from './constants';
 import { createTestController, testController, watchers } from './controller/testController';
@@ -65,7 +65,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
                 // workaround: wait more time to make sure Language Server has updated all caches
                 setTimeout(() => {
                     testSourceProvider.clear();
-                    commands.executeCommand(JavaTestRunnerCommands.REFRESH_TEST_EXPLORER);
+                    refreshExplorer();
                 }, 1000 /*ms*/);
             }));
         }
@@ -74,7 +74,7 @@ async function doActivate(_operationId: string, context: ExtensionContext): Prom
             const onDidProjectsImport: Event<Uri[]> = extensionApi.onDidProjectsImport;
             context.subscriptions.push(onDidProjectsImport(async () => {
                 testSourceProvider.clear();
-                commands.executeCommand(JavaTestRunnerCommands.REFRESH_TEST_EXPLORER);
+                refreshExplorer();
             }));
         }
 
@@ -107,7 +107,6 @@ function registerComponents(context: ExtensionContext): void {
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.JAVA_TEST_GENERATE_TESTS, ((uri: Uri, startPosition: number) => generateTests(uri, startPosition))),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.RUN_FROM_TEST_EXPLORER, async (node: TestItem, launchConfiguration: DebugConfiguration) => await runTestsFromTestExplorer(node, launchConfiguration, false)),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.DEBUG_FROM_TEST_EXPLORER, async (node: TestItem, launchConfiguration: DebugConfiguration) => await runTestsFromTestExplorer(node, launchConfiguration, false)),
-        instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.REFRESH_TEST_EXPLORER, async () => await refresh()),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.RUN_TEST_FROM_JAVA_PROJECT_EXPLORER, async (node: any) => await runTestsFromJavaProjectExplorer(node, false /* isDebug */)),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.DEBUG_TEST_FROM_JAVA_PROJECT_EXPLORER, async (node: any) => await runTestsFromJavaProjectExplorer(node, true /* isDebug */)),
         instrumentOperationAsVsCodeCommand(JavaTestRunnerCommands.GO_TO_TEST, async () => await navigateToTestOrTarget(true)),


### PR DESCRIPTION
follow-up of #1384 

- since the platform already registered the command in palette,
  the existing one from Java side can be removed.


https://user-images.githubusercontent.com/6193897/156951398-46c7feca-1bc6-4302-871a-c57eddddc8a6.mp4

Signed-off-by: sheche <sheche@microsoft.com>