### PR TITLE
fix: Support Eclipse project which store sources at root

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/ProjectTestUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/ProjectTestUtils.java
@@ -136,6 +136,11 @@ public final class ProjectTestUtils {
 
     private static String parseTestSourcePathString(IClasspathEntry entry, IJavaProject project) {
         final IPath relativePath = entry.getPath().makeRelativeTo(project.getPath());
+        // Eclipse project that source files stored directly at project root
+        if (relativePath.isEmpty()) {
+            return project.getProject().getLocation().toOSString();
+        }
+
         return project.getProject().getFolder(relativePath).getLocation().toOSString();
     }
 


### PR DESCRIPTION
fix #1398 

This is the case that when users save the sources at the project root for an Eclipse project

![image](https://user-images.githubusercontent.com/6193897/161936578-1d69351d-507d-409c-98c4-e4c2dce0a6d6.png)

Signed-off-by: sheche <sheche@microsoft.com>