### PR TITLE
feat: Simplify the stacktrace

### DIFF
--- a/src/runners/baseRunner/RunnerResultAnalyzer.ts
+++ b/src/runners/baseRunner/RunnerResultAnalyzer.ts
@@ -31,8 +31,8 @@ export abstract class RunnerResultAnalyzer {
             }
 
             const location: string = traceResults[4];
-            let sourceName: string | undefined = undefined;
-            let lineNumLiteral: string | undefined = undefined;
+            let sourceName: string | undefined;
+            let lineNumLiteral: string | undefined;
             const locationResult: RegExpExecArray | null = /([\w-$]+\.java):(\d+)/.exec(location);
             if (locationResult) {
                 sourceName = locationResult[1];
@@ -44,7 +44,6 @@ export abstract class RunnerResultAnalyzer {
             } else {
                 const atLiteral: string = traceResults[1];
                 const optionalModuleName: string = traceResults[2] || '';
-    
                 traces.appendText(atLiteral);
                 traces.appendMarkdown(`${optionalModuleName + fullyQualifiedName}([${sourceName}:${lineNumLiteral}](command:_java.test.openStackTrace?${encodeURIComponent(JSON.stringify([data, projectName]))}))`);
                 if (currentItem && path.basename(currentItem.uri?.fsPath || '') === sourceName) {
@@ -66,7 +65,7 @@ export abstract class RunnerResultAnalyzer {
     }
 
     private isExcluded(stacktrace: string): boolean {
-        return this.getStacktraceFilter().some(s => {
+        return this.getStacktraceFilter().some((s: string) => {
             return stacktrace.includes(s);
         });
     }

--- a/src/runners/baseRunner/RunnerResultAnalyzer.ts
+++ b/src/runners/baseRunner/RunnerResultAnalyzer.ts
@@ -13,21 +13,49 @@ export abstract class RunnerResultAnalyzer {
     public abstract processData(data: string): void;
     protected testMessageLocation: Location | undefined;
 
-    protected processStackTrace(data: string, traces: MarkdownString, assertionFailure: TestMessage | undefined, currentItem: TestItem | undefined, projectName: string): void {
-        const traceRegExp: RegExp = /(\s?at\s+)([\w$\\.]+\/)?((?:[\w$]+\.)+[<\w$>]+)\(([\w-$]+\.java):(\d+)\)/;
+    /**
+     * Return a string array which contains the stacktraces that need to be filtered.
+     * All the stacktraces which include the element in the return array will be removed.
+     */
+    protected getStacktraceFilter(): string[] {
+        return [];
+    }
 
+    protected processStackTrace(data: string, traces: MarkdownString, assertionFailure: TestMessage | undefined, currentItem: TestItem | undefined, projectName: string): void {
+        const traceRegExp: RegExp = /(\s?at\s+)([\w$\\.]+\/)?((?:[\w$]+\.)+[<\w$>]+)\((.*)\)/;
         const traceResults: RegExpExecArray | null = traceRegExp.exec(data);
-        if (traceResults && traceResults.length === 6) {
-            traces.appendText(traceResults[1]);
-            traces.appendMarkdown(`${(traceResults[2] || '') + traceResults[3]}([${traceResults[4]}:${traceResults[5]}](command:_java.test.openStackTrace?${encodeURIComponent(JSON.stringify([data, projectName]))}))`);
-            if (currentItem && path.basename(currentItem.uri?.fsPath || '') === traceResults[4]) {
-                const lineNum: number = parseInt(traceResults[5], 10);
-                if (currentItem.uri) {
-                    this.testMessageLocation = new Location(currentItem.uri, new Range(lineNum - 1, 0, lineNum, 0));
-                }
-                if (assertionFailure) {
-                    assertionFailure.location = this.testMessageLocation;
-                    setTestState(this.testContext.testRun, currentItem, TestResultState.Failed, assertionFailure);
+        if (traceResults) {
+            const fullyQualifiedName: string = traceResults[3];
+            if (this.isExcluded(fullyQualifiedName)) {
+                return;
+            }
+
+            const location: string = traceResults[4];
+            let sourceName: string | undefined = undefined;
+            let lineNumLiteral: string | undefined = undefined;
+            const locationResult: RegExpExecArray | null = /([\w-$]+\.java):(\d+)/.exec(location);
+            if (locationResult) {
+                sourceName = locationResult[1];
+                lineNumLiteral = locationResult[2];
+            }
+
+            if (!sourceName || !lineNumLiteral) {
+                traces.appendText(data);
+            } else {
+                const atLiteral: string = traceResults[1];
+                const optionalModuleName: string = traceResults[2] || '';
+    
+                traces.appendText(atLiteral);
+                traces.appendMarkdown(`${optionalModuleName + fullyQualifiedName}([${sourceName}:${lineNumLiteral}](command:_java.test.openStackTrace?${encodeURIComponent(JSON.stringify([data, projectName]))}))`);
+                if (currentItem && path.basename(currentItem.uri?.fsPath || '') === sourceName) {
+                    const lineNum: number = parseInt(lineNumLiteral, 10);
+                    if (currentItem.uri) {
+                        this.testMessageLocation = new Location(currentItem.uri, new Range(lineNum - 1, 0, lineNum, 0));
+                    }
+                    if (assertionFailure) {
+                        assertionFailure.location = this.testMessageLocation;
+                        setTestState(this.testContext.testRun, currentItem, TestResultState.Failed, assertionFailure);
+                    }
                 }
             }
         } else {
@@ -35,5 +63,11 @@ export abstract class RunnerResultAnalyzer {
             traces.appendText(data.replace(/</g, '[').replace(/>/g, ']'));
         }
         traces.appendMarkdown('<br/>');
+    }
+
+    private isExcluded(stacktrace: string): boolean {
+        return this.getStacktraceFilter().some(s => {
+            return stacktrace.includes(s);
+        });
     }
 }

--- a/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
+++ b/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
@@ -195,6 +195,24 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
         this.recordingType = RecordingType.None;
     }
 
+    protected getStacktraceFilter(): string[] {
+        return [
+            'org.eclipse.jdt.internal.junit.runner.',
+            'org.eclipse.jdt.internal.junit4.runner.',
+            'org.eclipse.jdt.internal.junit5.runner.',
+            'org.eclipse.jdt.internal.junit.ui.',
+            'junit.framework.TestCase',
+            'junit.framework.TestResult',
+            'junit.framework.TestResult$1',
+            'junit.framework.TestSuite',
+            'junit.framework.Assert',
+            'org.junit.',
+            'java.lang.reflect.Method.invoke',
+            'sun.reflect.',
+            'jdk.internal.reflect.',
+        ];
+    }
+
     private enlistToTestMapping(message: string): void {
         const regExp: RegExp = /([^\\,]|\\\,?)+/gm;
         // See MessageId.TestTree's comment for its format

--- a/src/runners/testngRunner/TestNGRunnerResultAnalyzer.ts
+++ b/src/runners/testngRunner/TestNGRunnerResultAnalyzer.ts
@@ -129,6 +129,20 @@ export class TestNGRunnerResultAnalyzer extends RunnerResultAnalyzer {
         this.currentTestState = TestResultState.Queued;
         this.currentItem = undefined;
     }
+
+    protected getStacktraceFilter(): string[] {
+        return [
+            'com.microsoft.java.test.runner.',
+            'org.testng.internal.',
+            'org.testng.TestRunner',
+            'org.testng.SuiteRunner',
+            'org.testng.TestNG',
+            'org.testng.Assert',
+            'java.lang.reflect.Method.invoke',
+            'sun.reflect.',
+            'jdk.internal.reflect.',
+        ];
+    }
 }
 
 interface ITestNGOutputData {


### PR DESCRIPTION
- Simplify the stacktrace by excluding internal traces, which defined in
  getStacktraceFilter().

fix #1281

Signed-off-by: sheche <sheche@microsoft.com>