### PR TITLE
fix: Always display the test message in the test's range

### DIFF
--- a/src/runners/baseRunner/RunnerResultAnalyzer.ts
+++ b/src/runners/baseRunner/RunnerResultAnalyzer.ts
@@ -49,7 +49,11 @@ export abstract class RunnerResultAnalyzer {
                 if (currentItem && path.basename(currentItem.uri?.fsPath || '') === sourceName) {
                     const lineNum: number = parseInt(lineNumLiteral, 10);
                     if (currentItem.uri) {
-                        this.testMessageLocation = new Location(currentItem.uri, new Range(lineNum - 1, 0, lineNum, 0));
+                        if (!currentItem.range || (currentItem.range.start.line < lineNum && currentItem.range.end.line > lineNum)) {
+                            this.testMessageLocation = new Location(currentItem.uri, new Range(lineNum - 1, 0, lineNum, 0));
+                        } else {
+                            this.testMessageLocation = new Location(currentItem.uri, new Range(currentItem.range.start.line, 0, currentItem.range.start.line, 0));
+                        }
                     }
                     if (assertionFailure) {
                         assertionFailure.location = this.testMessageLocation;

--- a/test/suite/config.test.ts
+++ b/test/suite/config.test.ts
@@ -29,7 +29,7 @@ suite('JUnit Runner Analyzer Tests', () => {
     });
 
     test("test launch configuration", async () => {
-        const testItem = generateTestItem(testController, 'junit@junit4.TestAnnotation#shouldPass', TestKind.JUnit, '=junit/src\\/test\\/java=/optional=/true=/=/maven.pomderived=/true=/=/test=/true=/<junit4{TestAnnotation.java[TestAnnotation~shouldPass');
+        const testItem = generateTestItem(testController, 'junit@junit4.TestAnnotation#shouldPass', TestKind.JUnit, undefined, '=junit/src\\/test\\/java=/optional=/true=/=/maven.pomderived=/true=/=/test=/true=/<junit4{TestAnnotation.java[TestAnnotation~shouldPass');
         const testRunRequest = new TestRunRequest([testItem], []);
         const testRun = testController.createTestRun(testRunRequest);
         const runnerContext: IRunTestContext = {

--- a/test/suite/utils.ts
+++ b/test/suite/utils.ts
@@ -9,7 +9,7 @@ import { TestController, TestItem, Uri, Range, extensions, commands, workspace }
 import { dataCache } from "../../src/controller/testItemDataCache";
 import { TestKind, TestLevel } from "../../src/types";
 
-export function generateTestItem(testController: TestController, id: string, testKind: TestKind, jdtHandler?: string): TestItem {
+export function generateTestItem(testController: TestController, id: string, testKind: TestKind, range?: Range, jdtHandler?: string): TestItem {
     if (!id) {
         throw new Error('id cannot be null');
     }
@@ -19,7 +19,7 @@ export function generateTestItem(testController: TestController, id: string, tes
     const label = id.substring(id.indexOf('#') + 1);
 
     const testItem = testController.createTestItem(id, label, Uri.file('/mock/test/TestAnnotation.java'));
-    testItem.range = new Range(0, 0, 0, 0);
+    testItem.range = range || new Range(0, 0, 0, 0);
     dataCache.set(testItem, {
         jdtHandler: jdtHandler || '',
         fullName,


### PR DESCRIPTION
fix #1392

The test message should always display inside the range of a test message. Even when its stacktrace locates outside of it. In this case, we simply set the test message location at the first line of the test case.

Signed-off-by: sheche <sheche@microsoft.com>