### PR TITLE
fix: re-run invocations from all methods in class

### DIFF
--- a/src/controller/testController.ts
+++ b/src/controller/testController.ts
@@ -446,11 +446,15 @@ function mergeTestMethods(testItems: TestItem[]): TestItem[][] {
 
     const testMethods: TestItem[][] = [];
 
-    for (const [key, value] of testMapping) {
-        if (key.children.size === value.size) {
-            classMapping.set(key.id, key);
+    for (const [clazz, methods] of testMapping) {
+        // if all methods of a class are selected, prefer running the class instead, to execute them together
+        if (clazz.children.size === methods.size
+            // but do not run the whole class when a method is restricted to a single invocation,
+            // since restricting class items to single invocations is not supported
+            && !([...methods].some((m: TestItem) => dataCache.get(m)?.uniqueId))) {
+            classMapping.set(clazz.id, clazz);
         } else {
-            for (const method of value.values()) {
+            for (const method of methods.values()) {
                 testMethods.push([method]);
             }
         }


### PR DESCRIPTION
Only run class instead of methods if no method is restricted to a single invocation.

The example from the issue may now be debugged as expected (no more execution of all parameter-sets):
![rerun_bug_fixed](https://user-images.githubusercontent.com/53265832/164530542-ddf3447f-94bd-41ad-9e71-db1fe91717cf.gif)

resolve https://github.com/microsoft/vscode-java-test/issues/1411