### PR TITLE
fix: Improve the error handling

### DIFF
--- a/src/controller/utils.ts
+++ b/src/controller/utils.ts
@@ -226,7 +226,9 @@ export async function updateItemForDocument(uri: Uri, testTypes?: IJavaTestItem[
         belongingPackage = findBelongingPackageItem(testTypes[0]) || await resolveBelongingPackage(uri);
     }
     if (!belongingPackage) {
-        sendError(new Error('Failed to find the belonging package'));
+        if (testTypes.length > 0) {
+            sendError(new Error('Failed to find the belonging package'));
+        }
         return [];
     }
 


### PR DESCRIPTION
Only send the package not found error when the test cases are found in compilation unit but cannot find the belonging package.

Signed-off-by: Sheng Chen <sheche@microsoft.com>