### PR TITLE
fix: Cannot run tests from Java Projects view

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,17 +89,17 @@
             "view/item/context": [
                 {
                     "command": "java.test.runFromJavaProjectExplorer",
-                    "when": "view == javaProjectExplorer && viewItem =~ /java:(type|package|packageRoot)(?=.*?\\b\\+uri\\b)(?=.*?\\b\\+source\\b)(?=.*?\\b\\+test\\b)/",
+                    "when": "view == javaProjectExplorer && viewItem =~ /java:(type|package|packageRoot)(?=.*?\\b\\+uri\\b)(?=.*?\\b\\+test\\b)(?!.*?\\b\\+resource\\b)/",
                     "group": "8_execution@10"
                 },
                 {
                     "command": "java.test.debugFromJavaProjectExplorer",
-                    "when": "view == javaProjectExplorer && viewItem =~ /java:(type|package|packageRoot)(?=.*?\\b\\+uri\\b)(?=.*?\\b\\+source\\b)(?=.*?\\b\\+test\\b)/",
+                    "when": "view == javaProjectExplorer && viewItem =~ /java:(type|package|packageRoot)(?=.*?\\b\\+uri\\b)(?=.*?\\b\\+test\\b)(?!.*?\\b\\+resource\\b)/",
                     "group": "8_execution@20"
                 },
                 {
                     "command": "java.test.runFromJavaProjectExplorer",
-                    "when": "view == javaProjectExplorer && viewItem =~ /java:(type|package|packageRoot)(?=.*?\\b\\+uri\\b)(?=.*?\\b\\+source\\b)(?=.*?\\b\\+test\\b)/",
+                    "when": "view == javaProjectExplorer && viewItem =~ /java:(type|package|packageRoot)(?=.*?\\b\\+uri\\b)(?=.*?\\b\\+test\\b)(?!.*?\\b\\+resource\\b)/",
                     "group": "inline@run_0"
                 }
             ],

--- a/src/commands/projectExplorerCommands.ts
+++ b/src/commands/projectExplorerCommands.ts
@@ -32,7 +32,7 @@ export async function runTestsFromJavaProjectExplorer(node: any, isDebug: boolea
         const nodeFsPath: string = Uri.parse(node._nodeData.uri).fsPath;
         projectItem.children.forEach((child: TestItem) => {
             const itemPath: string = child.uri?.fsPath || '';
-            if (isHierarchicalMode || node._nodeData.kind === 4 /*packageRoot*/) {
+            if (isHierarchicalMode || node._nodeData.kind === 3 /*packageRoot*/) {
                 // if the selected node is a package root or the view is in hierarchical mode,
                 // all the test items whose path start from the path of the selected node will be added
                 if (itemPath.startsWith(nodeFsPath)) {
@@ -55,7 +55,7 @@ export async function runTestsFromJavaProjectExplorer(node: any, isDebug: boolea
 function getTestLevel(nodeData: any): TestLevel {
     // The command will only register on the class/package/packageRoot
     // nodes of the Java Project explorer
-    if (nodeData.kind === 6 /*PrimaryType*/) {
+    if (nodeData.kind === 5 /*PrimaryType*/) {
         return TestLevel.Class;
     } else {
         return TestLevel.Package;


### PR DESCRIPTION
fix #1574 

Here using a negative lookahead to eliminate `resource` node, this is better than the previous approach.