### PR TITLE
Add support to specify java executable to use for test

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,8 @@ module.exports = {
     ],
     'root': true,
     'ignorePatterns': [
-        '**/*.d.ts'
+        '**/*.d.ts',
+        '**/*.test.ts'
     ],
     'rules': {
         '@typescript-eslint/no-inferrable-types': 'off',

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
                         },
                         "javaExec": {
                             "type": "string",
-                            "description": "%configuration.java.test.config.javaExec.description%",
+                            "markdownDescription": "%configuration.java.test.config.javaExec.description%",
                             "default": ""
                         },
                         "vmArgs": {
@@ -388,7 +388,7 @@
                             },
                             "javaExec": {
                                 "type": "string",
-                                "description": "%configuration.java.test.config.javaExec.description%",
+                                "markdownDescription": "%configuration.java.test.config.javaExec.description%",
                                 "default": ""
                             },
                             "vmargs": {

--- a/package.json
+++ b/package.json
@@ -248,6 +248,11 @@
                             "description": "%configuration.java.test.config.modulePaths.description%",
                             "default": []
                         },
+                        "javaExec": {
+                            "type": "string",
+                            "description": "%configuration.java.test.config.javaExec.description%",
+                            "default": ""
+                        },
                         "vmArgs": {
                             "type": "array",
                             "items": {
@@ -380,6 +385,11 @@
                                 },
                                 "description": "%configuration.java.test.config.modulePaths.description%",
                                 "default": []
+                            },
+                            "javaExec": {
+                                "type": "string",
+                                "description": "%configuration.java.test.config.javaExec.description%",
+                                "default": ""
                             },
                             "vmargs": {
                                 "type": "array",

--- a/package.nls.json
+++ b/package.nls.json
@@ -31,6 +31,7 @@
     "configuration.java.test.config.testKind.description": "Specify the targeting test framework for this test configuration. Supported values are `junit`, `testng`.",
     "configuration.java.test.config.filters.description": "Specify the test filters.",
     "configuration.java.test.config.filters.tags.description": "Specify the tags to be included or excluded. \n\nTags having `!` as the prefix will be **excluded**. \n\nNote: This setting **only** takes effect when `testKind` is set to `junit`.",
+    "configuration.java.test.config.javaExec.description": "The path to java executable to use. If unset project JDK's java executable is used.",
     "contributes.viewsWelcome.inLightWeightMode": "No test cases are listed because the Java Language Server is currently running in [LightWeight Mode](https://aka.ms/vscode-java-lightweight). To show test cases, click on the button to switch to Standard Mode.\n[Switch to Standard Mode](command:java.server.mode.switch?%5B%22Standard%22,true%5D)",
     "contributes.viewsWelcome.enableTests": "Click below button to configure a test framework for your project.\n[Enable Java Tests](command:_java.test.enableTests)"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -31,7 +31,7 @@
     "configuration.java.test.config.testKind.description": "Specify the targeting test framework for this test configuration. Supported values are `junit`, `testng`.",
     "configuration.java.test.config.filters.description": "Specify the test filters.",
     "configuration.java.test.config.filters.tags.description": "Specify the tags to be included or excluded. \n\nTags having `!` as the prefix will be **excluded**. \n\nNote: This setting **only** takes effect when `testKind` is set to `junit`.",
-    "configuration.java.test.config.javaExec.description": "The path to java executable to use. If unset project JDK's java executable is used.",
+    "configuration.java.test.config.javaExec.description": "The path to java executable to use. For example: `C:\\Program Files\\jdk\\bin\\java.exe`. If unset project JDK's java executable is used.",
     "contributes.viewsWelcome.inLightWeightMode": "No test cases are listed because the Java Language Server is currently running in [LightWeight Mode](https://aka.ms/vscode-java-lightweight). To show test cases, click on the button to switch to Standard Mode.\n[Switch to Standard Mode](command:java.server.mode.switch?%5B%22Standard%22,true%5D)",
     "contributes.viewsWelcome.enableTests": "Click below button to configure a test framework for your project.\n[Enable Java Tests](command:_java.test.enableTests)"
 }

--- a/src/controller/testController.ts
+++ b/src/controller/testController.ts
@@ -225,7 +225,7 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
                         }
                         try {
                             await runner.setup();
-                            const resolvedConfiguration: DebugConfiguration = option.launchConfiguration ?? await resolveLaunchConfigurationForRunner(runner, testContext, config);
+                            const resolvedConfiguration: DebugConfiguration = mergeConfigurations(option.launchConfiguration, config) ?? await resolveLaunchConfigurationForRunner(runner, testContext, config);
                             resolvedConfiguration.__progressId = option.progressReporter?.getId();
                             delegatedToDebugger = true;
                             await runner.run(resolvedConfiguration, token, option.progressReporter);
@@ -244,6 +244,21 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
         run.end();
     }
 });
+
+function mergeConfigurations(launchConfiguration: DebugConfiguration | undefined, config: any): DebugConfiguration | undefined {
+    if (!launchConfiguration) {
+        return undefined;
+    }
+
+    const entryKeys: string[] = Object.keys(config);
+    for (const configKey of entryKeys) {
+        // for now we merge launcher properties which doesn't have a value.
+        if (!launchConfiguration[configKey]) {
+            launchConfiguration[configKey] = config[configKey];
+        }
+    }
+    return launchConfiguration;
+}
 
 /**
  * Set all the test item to queued state

--- a/src/runConfigs.ts
+++ b/src/runConfigs.ts
@@ -35,6 +35,12 @@ export interface IExecutionConfig {
     args?: any[];
 
     /**
+     * The path to java executable to use. If undefined project JDK's java executable is used.
+     * @since 0.39.2
+     */
+    javaExec?: string;
+
+    /**
      * the extra options and system properties for the JVM.
      * It's deprecated, we should align with the debug launch configuration, which is 'vmArgs'.
      * @since 0.14.0

--- a/src/runConfigs.ts
+++ b/src/runConfigs.ts
@@ -36,7 +36,7 @@ export interface IExecutionConfig {
 
     /**
      * The path to java executable to use. If undefined project JDK's java executable is used.
-     * @since 0.39.2
+     * @since 0.40.0
      */
     javaExec?: string;
 

--- a/src/utils/launchUtils.ts
+++ b/src/utils/launchUtils.ts
@@ -47,6 +47,7 @@ export async function resolveLaunchConfigurationForRunner(runner: BaseRunner, te
             sourcePaths: config?.sourcePaths,
             preLaunchTask: config?.preLaunchTask,
             postDebugTask: config?.postDebugTask,
+            javaExec: config?.javaExec,
         };
     }
 
@@ -76,6 +77,7 @@ export async function resolveLaunchConfigurationForRunner(runner: BaseRunner, te
         sourcePaths: config?.sourcePaths,
         preLaunchTask: config?.preLaunchTask,
         postDebugTask: config?.postDebugTask,
+        javaExec: config?.javaExec,
     };
 }
 

--- a/test/suite/config.test.ts
+++ b/test/suite/config.test.ts
@@ -46,18 +46,19 @@ suite('JUnit Runner Analyzer Tests', () => {
                 "/a/b/c.jar",
                 "/foo/bar.jar"
             ],
-            modulePaths: [
-                "/test/module.jar",
-            ],
             env: {
                 test: "test",
             },
             envFile: "${workspaceFolder}/.env",
+            javaExec: "/usr/bin/java",
+            modulePaths: [
+                "/test/module.jar",
+            ],
+            postDebugTask: "test",
+            preLaunchTask: "test",
             sourcePaths: [
                 "/a/b/c.jar"
-            ],
-            preLaunchTask: "test",
-            postDebugTask: "test"
+            ]
         });
         assert.strictEqual(configuration.env.test, "test");
         assert.strictEqual(configuration.envFile, "${workspaceFolder}/.env");
@@ -67,5 +68,6 @@ suite('JUnit Runner Analyzer Tests', () => {
         assert.strictEqual(configuration.modulePaths[0], "/test/module.jar");
         assert.strictEqual(configuration.classPaths[0], "/a/b/c.jar");
         assert.strictEqual(configuration.classPaths[1], "/foo/bar.jar");
+        assert.strictEqual(configuration.javaExec, "/usr/bin/java");
     });
 });


### PR DESCRIPTION
This PR adds support for specifying a different JRE (by providing the java executable) to be used for running the test. This helps when some tests needs to be executed against a different java version to

- Make sure certain application components are future proof.
- Debug issues which has raised when application was running with a newer java version, Which a test is used to reproduce that error.
- etc.