### PR TITLE
fix: JUnit5 DynamicContainer are not working

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,8 +66,18 @@ export namespace Context {
 }
 
 /**
- * This is the prefix of the invocation test item's id.
- * Invocation test items are created during test run.
- * For example, the invocations from a parameterized test.
+ * The different part keys returned by the JUnit test runner,
+ * which are used to identify the test cases.
  */
-export const INVOCATION_PREFIX: string = '[__INVOCATION__]-';
+export namespace JUnitTestPart {
+    export const CLASS: string = 'class:';
+    export const NESTED_CLASS: string = 'nested-class:';
+    export const METHOD: string = 'method:';
+    export const TEST_FACTORY: string = 'test-factory:';
+    // Property id is for jqwik
+    export const PROPERTY: string = 'property:';
+    export const TEST_TEMPLATE: string = 'test-template:';
+    export const TEST_TEMPLATE_INVOCATION: string = 'test-template-invocation:';
+    export const DYNAMIC_CONTAINER: string = 'dynamic-container:';
+    export const DYNAMIC_TEST: string = 'dynamic-test:';
+}

--- a/src/controller/testController.ts
+++ b/src/controller/testController.ts
@@ -6,7 +6,6 @@ import * as path from 'path';
 import { CancellationToken, DebugConfiguration, Disposable, FileSystemWatcher, RelativePattern, TestController, TestItem, TestRun, TestRunProfileKind, TestRunRequest, tests, TestTag, Uri, window, workspace, WorkspaceFolder } from 'vscode';
 import { instrumentOperation, sendError, sendInfo } from 'vscode-extension-telemetry-wrapper';
 import { refreshExplorer } from '../commands/testExplorerCommands';
-import { INVOCATION_PREFIX } from '../constants';
 import { IProgressReporter } from '../debugger.api';
 import { progressProvider } from '../extension';
 import { testSourceProvider } from '../provider/testSourceProvider';
@@ -420,7 +419,7 @@ function removeNonRerunTestInvocations(testItems: TestItem[]): void {
         if (rerunMethods.includes(item)) {
             continue;
         }
-        if (item.id.startsWith(INVOCATION_PREFIX)) {
+        if (dataCache.get(item)?.testLevel === TestLevel.Invocation) {
             item.parent?.children.delete(item.id);
             continue;
         }

--- a/test/suite/JUnitAnalyzer.test.ts
+++ b/test/suite/JUnitAnalyzer.test.ts
@@ -430,7 +430,7 @@ org.opentest4j.AssertionFailedError: expected: <1> but was: <2>
         // We need to stub this method to avoid issues with the TestController
         // not being set up in the non-test version of the utils file.
         const stub = sinon.stub(analyzer, "enlistDynamicMethodToTestMapping");
-        const dummy = generateTestItem(testController, '[__INVOCATION__]-dummy', TestKind.JUnit5, new Range(10, 0, 16, 0));
+        const dummy = generateTestItem(testController, 'dummy', TestKind.JUnit5, new Range(10, 0, 16, 0));
         stub.returns(dummy);
         analyzer.analyzeData(testRunnerOutput);
 
@@ -498,7 +498,45 @@ org.opentest4j.AssertionFailedError: expected: <1> but was: <2>
         // We need to stub this method to avoid issues with the TestController
         // not being set up in the non-test version of the utils file.
         const stub = sinon.stub(analyzer, "enlistDynamicMethodToTestMapping");
-        const dummy = generateTestItem(testController, '[__INVOCATION__]-dummy', TestKind.JUnit5, new Range(10, 0, 16, 0));
+        const dummy = generateTestItem(testController, 'dummy', TestKind.JUnit5, new Range(10, 0, 16, 0));
+        stub.returns(dummy);
+        analyzer.analyzeData(testRunnerOutput);
+
+        sinon.assert.calledWith(startedSpy, dummy);
+        sinon.assert.calledWith(passedSpy, dummy);
+    });
+
+    test("can handle DynamicContainer", () => {
+        const testItem = generateTestItem(testController, 'junit@junit5.TestFactoryTest#testContainers()', TestKind.JUnit5, new Range(10, 0, 16, 0));
+        const testRunRequest = new TestRunRequest([testItem], []);
+        const testRun = testController.createTestRun(testRunRequest);
+        const startedSpy = sinon.spy(testRun, 'started');
+        const passedSpy = sinon.spy(testRun, 'passed');
+        const testRunnerOutput = `%TESTC  0 v2
+%TSTTREE2,junit5.TestFactoryTest,true,1,false,1,TestFactoryTest,,[engine:junit-jupiter]/[class:junit5.TestFactoryTest]
+%TSTTREE3,testContainers(junit5.TestFactoryTest),true,0,false,2,testContainers(),,[engine:junit-jupiter]/[class:junit5.TestFactoryTest]/[test-factory:testContainers()]
+%TSTTREE4,testContainers(junit5.TestFactoryTest),true,0,true,3,Container,,[engine:junit-jupiter]/[class:junit5.TestFactoryTest]/[test-factory:testContainers()]/[dynamic-container:#1]
+%TSTTREE5,testContainers(junit5.TestFactoryTest),false,1,true,4,Test,,[engine:junit-jupiter]/[class:junit5.TestFactoryTest]/[test-factory:testContainers()]/[dynamic-container:#1]/[dynamic-test:#1]
+%TESTS  5,testContainers(junit5.TestFactoryTest)
+
+%TESTE  5,testContainers(junit5.TestFactoryTest)
+
+%RUNTIME103`;
+        const runnerContext: IRunTestContext = {
+            isDebug: false,
+            kind: TestKind.JUnit5,
+            projectName: 'junit',
+            testItems: [testItem],
+            testRun: testRun,
+            workspaceFolder: workspace.workspaceFolders?.[0]!,
+        };
+
+        const analyzer = new JUnitRunnerResultAnalyzer(runnerContext);
+
+        // We need to stub this method to avoid issues with the TestController
+        // not being set up in the non-test version of the utils file.
+        const stub = sinon.stub(analyzer, "enlistDynamicMethodToTestMapping");
+        const dummy = generateTestItem(testController, 'dummy', TestKind.JUnit5, new Range(10, 0, 16, 0));
         stub.returns(dummy);
         analyzer.analyzeData(testRunnerOutput);
 

--- a/test/suite/testController.handleInvocations.test.ts
+++ b/test/suite/testController.handleInvocations.test.ts
@@ -1,14 +1,12 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { TestController, TestItem, tests, window } from "vscode";
-import { INVOCATION_PREFIX } from '../../src/constants';
 import { handleInvocations } from '../../src/controller/testController';
 import { dataCache } from "../../src/controller/testItemDataCache";
 import { TestKind, TestLevel } from "../../src/types";
 import { setupTestEnv } from './utils';
 
 function generateTestItem(testController: TestController, id: string, testKind: TestKind, testLevel: TestLevel, uniqueId?: string): TestItem {
-    id = testLevel === TestLevel.Invocation ? INVOCATION_PREFIX + id : id;
     const testItem = testController.createTestItem(id, id + '_label');
     dataCache.set(testItem, {
         jdtHandler: id + '_jdtHandler',

--- a/test/test-projects/junit/src/test/java/junit5/TestFactoryTest.java
+++ b/test/test-projects/junit/src/test/java/junit5/TestFactoryTest.java
@@ -1,10 +1,15 @@
 package junit5;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.function.ThrowingConsumer;
@@ -16,5 +21,12 @@ class TestFactoryTest {
         final Function<Long, String> testNames = input -> "TestInput " + input;
         final ThrowingConsumer<Long> test = input -> {assertEquals(1L, input);};
         return DynamicTest.stream(parameters, testNames, test);
+    }
+
+    @TestFactory
+    public Stream<DynamicContainer> testContainers() {
+        return Stream.of(dynamicContainer("Container", List.of(
+            dynamicTest("Test", () -> {assertTrue(true);})
+        )));
     }
 }


### PR DESCRIPTION
- Store the test data for the test invocations as well.
- Remove the logic that adding prefix to the invocations. Instead,
- Using the information returned from the runner to compose the ids.

fix #1617 