### PR TITLE
build: Update target platform

### DIFF
--- a/java-extension/com.microsoft.java.test.target/com.microsoft.java.test.tp.target
+++ b/java-extension/com.microsoft.java.test.target/com.microsoft.java.test.tp.target
@@ -30,12 +30,14 @@
             <repository location="https://download.eclipse.org/releases/2023-03/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.21.0/"/>
+           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.21.1/"/>
            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/jdtls/snapshots/repository/latest/"/>
+            <!-- Latest JDT.LS requires JUnit 5.10+, which will break test execution <= 5.9.3
+            See: https://github.com/microsoft/vscode-java-test/pull/1608#issue-1904190398 -->
+            <repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.30.0.202310302327/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>


### PR DESCRIPTION
The version of JDT.LS is fixed to prevent update junit to 5.10.x. See: https://github.com/microsoft/vscode-java-test/pull/1608#issue-1904190398 for the reason.

fix #1633