### PR TITLE
docs: Update JDK to 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The [Test Runner for Java](https://marketplace.visualstudio.com/items?itemName=v
 
 ## Requirements
 
-- JDK (version 11 or later)
+- JDK (version 17 or later)
 - VS Code (version 1.59.0 or later)
 - [Language Support for Java by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java)
 - [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)


### PR DESCRIPTION
The minimum JDK dependency may have reached 17 now
> org/eclipse/tycho/p2maven/repository/EclipsePluginArtifactHandler has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
