### PR TITLE
refactor - Remove the logic of eliminating spaces in param list

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -2,4 +2,3 @@
 // Licensed under the MIT license.
 
 export { activate, deactivate } from './src/extension';
-export * from './src/utils/commandUtils';

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/util/TestItemUtils.java
@@ -53,8 +53,7 @@ public class TestItemUtils {
                     // them out now.
                     final String methodName = JavaElementLabelsCore.getElementLabel(element,
                             JavaElementLabelsCore.ALL_DEFAULT)
-                            .replaceAll("<.*?>", "")
-                            .replaceAll(" ", "");
+                            .replaceAll("<.*?>", "");
                     return className + "#" + methodName;
                 } else {
                     return method.getDeclaringType().getFullyQualifiedName() + "#" + method.getElementName();

--- a/java-extension/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/testng/TestNGListener.java
+++ b/java-extension/com.microsoft.java.test.runner/src/main/java/com/microsoft/java/test/runner/testng/TestNGListener.java
@@ -72,12 +72,12 @@ public class TestNGListener
 
         for (final Class<?> paramClazz : result.getMethod().getConstructorOrMethod().getMethod().getParameterTypes()) {
             params.append(paramClazz.getSimpleName().replaceAll("<.*?>", ""));
-            params.append(",");
+            params.append(", ");
         }
 
         // Remove the last ", "
         if (params.length() > 0) {
-            params.delete(params.length() - 1, params.length());
+            params.delete(params.length() - 2, params.length());
         }
 
         return className + "#" + methodName + "(" + params.toString() + ")";

--- a/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
+++ b/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
@@ -224,14 +224,12 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
                 className = `${className}$${nestedClassName}`;
             } else if (part.startsWith(JUnitTestPart.TEST_TEMPLATE)) {
                 const rawMethodName: string = part.substring(JUnitTestPart.TEST_TEMPLATE.length)
-                    .replace(/\\,/g, ',')
-                    .replace(/ /g, '');
+                    .replace(/\\,/g, ',');
                 // If the method name exists then we want to include the '#' qualifier.
                 methodName = `#${this.getJUnit5MethodName(rawMethodName)}`;
             } else if (part.startsWith(JUnitTestPart.PROPERTY)) {
                 const rawMethodName: string = part.substring(JUnitTestPart.PROPERTY.length)
-                    .replace(/\\,/g, ',')
-                    .replace(/ /g, '');
+                    .replace(/\\,/g, ',');
                 // If the method name exists then we want to include the '#' qualifier.
                 methodName = `#${this.getJUnit5MethodName(rawMethodName)}`;
             } else if (part.startsWith(JUnitTestPart.TEST_TEMPLATE_INVOCATION)) {
@@ -285,11 +283,11 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
         const params: string[] = rawParamsString.split(',');
         let paramString: string = '';
         params.forEach((param: string) => {
-            paramString += `${param.substring(param.lastIndexOf('.') + 1)},`;
+            paramString += `${param.substring(param.lastIndexOf('.') + 1)}, `;
         });
-        // We want to remove the final comma.
+        // We want to remove the final comma and space.
         if (paramString.length > 0) {
-            paramString = paramString.substring(0, paramString.length - 1);
+            paramString = paramString.substring(0, paramString.length - 2);
         }
 
         const methodName: string = rawName.substring(0, rawName.indexOf('('));

--- a/test/suite/JUnitAnalyzer.test.ts
+++ b/test/suite/JUnitAnalyzer.test.ts
@@ -404,7 +404,7 @@ org.opentest4j.AssertionFailedError: expected: <1> but was: <2>
     });
 
     test("can handle test cases with more than 3 arguments", () => {
-        const testItem = generateTestItem(testController, 'junit@junit5.ParameterizedAnnotationTest#testMultiArguments(String,String,String)', TestKind.JUnit5, new Range(10, 0, 16, 0));
+        const testItem = generateTestItem(testController, 'junit@junit5.ParameterizedAnnotationTest#testMultiArguments(String, String, String)', TestKind.JUnit5, new Range(10, 0, 16, 0));
         const testRunRequest = new TestRunRequest([testItem], []);
         const testRun = testController.createTestRun(testRunRequest);
         const startedSpy = sinon.spy(testRun, 'started');
@@ -439,7 +439,7 @@ org.opentest4j.AssertionFailedError: expected: <1> but was: <2>
     });
 
     test("can handle normal test method with multiple arguments", () => {
-        const testItem = generateTestItem(testController, 'junit@junit5.VertxTest#test(Vertx,VertxTestContext)', TestKind.JUnit5, new Range(10, 0, 16, 0));
+        const testItem = generateTestItem(testController, 'junit@junit5.VertxTest#test(Vertx, VertxTestContext)', TestKind.JUnit5, new Range(10, 0, 16, 0));
         const testRunRequest = new TestRunRequest([testItem], []);
         const testRun = testController.createTestRun(testRunRequest);
         const startedSpy = sinon.spy(testRun, 'started');


### PR DESCRIPTION
Since test id returned from both the eclipse test runner and gradle test runner contain space between the param list. The previous logic to remove all spaces is redundant.