### PR TITLE
refactor - Extract the stacktrace parsing to util

### DIFF
--- a/src/runners/baseRunner/RunnerResultAnalyzer.ts
+++ b/src/runners/baseRunner/RunnerResultAnalyzer.ts
@@ -26,7 +26,7 @@ export abstract class RunnerResultAnalyzer {
         }
 
         const location: Location | undefined = processStackTraceLine(data, traces, currentItem, projectName);
-        if (!this.testMessageLocation && location) {
+        if (location) {
             this.testMessageLocation = location;
         }
     }

--- a/src/runners/baseRunner/RunnerResultAnalyzer.ts
+++ b/src/runners/baseRunner/RunnerResultAnalyzer.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as path from 'path';
-import { Location, MarkdownString, Range, TestItem } from 'vscode';
+import { Location, MarkdownString, TestItem } from 'vscode';
 import { IRunTestContext } from '../../types';
+import { processStackTraceLine } from '../utils';
 
 export abstract class RunnerResultAnalyzer {
     constructor(protected testContext: IRunTestContext) { }
@@ -21,46 +21,14 @@ export abstract class RunnerResultAnalyzer {
     }
 
     protected processStackTrace(data: string, traces: MarkdownString, currentItem: TestItem | undefined, projectName: string): void {
-        const traceRegExp: RegExp = /(\s?at\s+)([\w$\\.]+\/)?((?:[\w$]+\.)+[<\w$>]+)\((.*)\)/;
-        const traceResults: RegExpExecArray | null = traceRegExp.exec(data);
-        if (traceResults) {
-            const fullyQualifiedName: string = traceResults[3];
-            if (this.isExcluded(fullyQualifiedName)) {
-                return;
-            }
-
-            const location: string = traceResults[4];
-            let sourceName: string | undefined;
-            let lineNumLiteral: string | undefined;
-            const locationResult: RegExpExecArray | null = /([\w-$]+\.java):(\d+)/.exec(location);
-            if (locationResult) {
-                sourceName = locationResult[1];
-                lineNumLiteral = locationResult[2];
-            }
-
-            if (!sourceName || !lineNumLiteral) {
-                traces.appendText(data);
-            } else {
-                const atLiteral: string = traceResults[1];
-                const optionalModuleName: string = traceResults[2] || '';
-                traces.appendText(atLiteral);
-                traces.appendMarkdown(`${optionalModuleName + fullyQualifiedName}([${sourceName}:${lineNumLiteral}](command:_java.test.openStackTrace?${encodeURIComponent(JSON.stringify([data, projectName]))}))`);
-                if (currentItem && path.basename(currentItem.uri?.fsPath || '') === sourceName) {
-                    const lineNum: number = parseInt(lineNumLiteral, 10);
-                    if (currentItem.uri) {
-                        if (!currentItem.range || (currentItem.range.start.line + 1 < lineNum && currentItem.range.end.line + 1 > lineNum)) {
-                            this.testMessageLocation = new Location(currentItem.uri, new Range(lineNum - 1, 0, lineNum, 0));
-                        } else {
-                            this.testMessageLocation = new Location(currentItem.uri, new Range(currentItem.range.start.line, 0, currentItem.range.start.line, 0));
-                        }
-                    }
-                }
-            }
-        } else {
-            // '<' & '>' will be escaped when displaying the test message, so replacing them to '[' & ']'.
-            traces.appendText(data.replace(/</g, '[').replace(/>/g, ']'));
+        if (this.isExcluded(data)) {
+            return;
         }
-        traces.appendMarkdown('<br/>');
+
+        const location: Location | undefined = processStackTraceLine(data, traces, currentItem, projectName);
+        if (!this.testMessageLocation && location) {
+            this.testMessageLocation = location;
+        }
     }
 
     private isExcluded(stacktrace: string): boolean {


### PR DESCRIPTION
This is a common logic that can be reused by the gradle test runner