### PR TITLE
JaCoCo updated

### DIFF
--- a/scripts/buildJdtlsExt.js
+++ b/scripts/buildJdtlsExt.js
@@ -76,7 +76,7 @@ function findNewRequiredJar(fileName) {
 }
 
 function downloadJacocoAgent() {
-    const version = "0.8.12";
+    const version = "0.8.13";
     const jacocoAgentUrl = `https://repo1.maven.org/maven2/org/jacoco/org.jacoco.agent/${version}/org.jacoco.agent-${version}-runtime.jar`;
     const jacocoAgentPath = path.resolve('server', 'jacocoagent.jar');
     if (!fs.existsSync(jacocoAgentPath)) {


### PR DESCRIPTION
JaCoCo has only been partially updated to 0.8.13.

Currently, code coverage runs always give 0% coverage with JDK 24 because 0.8.12 is still used and is not compatible (exception is thrown).

With this PR, the code coverage run functionality is fixed with JDK 24.