### PR TITLE
fix - Update to Jacoco 0.8.14

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/META-INF/MANIFEST.MF
+++ b/java-extension/com.microsoft.java.test.plugin/META-INF/MANIFEST.MF
@@ -40,8 +40,8 @@ Require-Bundle: org.eclipse.jdt.core,
  org.apiguardian.api;bundle-version="1.0.0",
  org.apache.commons.lang3;bundle-version="3.1.0",
  com.google.gson;bundle-version="2.7.0",
- org.objectweb.asm;bundle-version="[9.8.0,9.9.0)",
- org.jacoco.core;bundle-version="0.8.12"
+ org.objectweb.asm;bundle-version="[9.9.0,9.10.0)",
+ org.jacoco.core;bundle-version="0.8.14"
 Export-Package: com.microsoft.java.test.plugin.launchers;x-friends:="com.microsoft.java.test.plugin.test",
  com.microsoft.java.test.plugin.model;x-friends:="com.microsoft.java.test.plugin.test",
  com.microsoft.java.test.plugin.coverage;x-friends:="com.microsoft.java.test.plugin.test",

--- a/java-extension/com.microsoft.java.test.target/com.microsoft.java.test.tp.target
+++ b/java-extension/com.microsoft.java.test.target/com.microsoft.java.test.tp.target
@@ -29,7 +29,7 @@
                 <dependency>
                     <groupId>org.jacoco</groupId>
                     <artifactId>org.jacoco.core</artifactId>
-                    <version>0.8.13</version>
+                    <version>0.8.14</version>
                 </dependency>
             </dependencies>
         </location>

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
             "./server/org.eclipse.jdt.junit4.runtime_1.3.100.v20231214-1952.jar",
             "./server/org.eclipse.jdt.junit5.runtime_1.1.300.v20231214-1952.jar",
             "./server/org.opentest4j_1.3.0.jar",
-            "./server/org.jacoco.core_0.8.13.202504020838.jar",
+            "./server/org.jacoco.core_0.8.14.202510111229.jar",
             "./server/com.microsoft.java.test.plugin-0.43.1.jar"
         ],
         "viewsWelcome": [

--- a/scripts/buildJdtlsExt.js
+++ b/scripts/buildJdtlsExt.js
@@ -76,7 +76,7 @@ function findNewRequiredJar(fileName) {
 }
 
 function downloadJacocoAgent() {
-    const version = "0.8.13";
+    const version = "0.8.14";
     const jacocoAgentUrl = `https://repo1.maven.org/maven2/org/jacoco/org.jacoco.agent/${version}/org.jacoco.agent-${version}-runtime.jar`;
     const jacocoAgentPath = path.resolve('server', 'jacocoagent.jar');
     if (!fs.existsSync(jacocoAgentPath)) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-java-test/issues/1796

Update to Jacoco 0.8.14, which requires org.objectweb.asm:9.9.0.
The caveat is the extension requires vscode-java 1.47.0 to work, i.e. the current vscode-java pre-release, since jacoco no longer works with asm 9.8.0.