### PR TITLE
fix: update parent node state when test completes

### DIFF
--- a/src/runners/baseRunner/RunnerResultAnalyzer.ts
+++ b/src/runners/baseRunner/RunnerResultAnalyzer.ts
@@ -2,10 +2,14 @@
 // Licensed under the MIT license.
 
 import { Location, MarkdownString, TestItem } from 'vscode';
-import { IRunTestContext } from '../../java-test-runner.api';
+import { dataCache, ITestItemData } from '../../controller/testItemDataCache';
+import { IRunTestContext, TestLevel, TestResultState } from '../../java-test-runner.api';
 import { processStackTraceLine } from '../utils';
 
 export abstract class RunnerResultAnalyzer {
+    // Track parent test item states to update them when all children complete
+    protected parentStates: Map<TestItem, ParentItemState> = new Map();
+
     constructor(protected testContext: IRunTestContext) { }
 
     public abstract analyzeData(data: string): void;
@@ -36,4 +40,95 @@ export abstract class RunnerResultAnalyzer {
             return stacktrace.includes(s);
         });
     }
+
+    /**
+     * Initialize parent state tracking for a test item.
+     * Counts how many method-level children are being tested.
+     */
+    protected initializeParentState(item: TestItem, triggeredTestsMapping: Map<string, TestItem>): void {
+        const parent: TestItem | undefined = item.parent;
+        if (!parent) {
+            return;
+        }
+
+        const parentData: ITestItemData | undefined = dataCache.get(parent);
+        if (!parentData || parentData.testLevel !== TestLevel.Class) {
+            return;
+        }
+
+        if (!this.parentStates.has(parent)) {
+            // Count how many method-level children are being tested (only count triggered tests)
+            let childCount: number = 0;
+            parent.children.forEach((child: TestItem) => {
+                const childData: ITestItemData | undefined = dataCache.get(child);
+                if (childData?.testLevel === TestLevel.Method && triggeredTestsMapping.has(child.id)) {
+                    childCount++;
+                }
+            });
+
+            this.parentStates.set(parent, {
+                started: false,
+                childrenTotal: childCount,
+                childrenCompleted: 0,
+                hasFailure: false,
+            });
+        }
+    }
+
+    /**
+     * Update parent test item when a child test starts.
+     * Marks the parent as "started" when the first child starts.
+     */
+    protected updateParentOnChildStart(item: TestItem): void {
+        const parent: TestItem | undefined = item.parent;
+        if (!parent) {
+            return;
+        }
+
+        const parentState: ParentItemState | undefined = this.parentStates.get(parent);
+        if (parentState && !parentState.started) {
+            parentState.started = true;
+            this.testContext.testRun.started(parent);
+        }
+    }
+
+    /**
+     * Update parent test item when a child test completes.
+     * Marks the parent as "passed" or "failed" when all children complete.
+     */
+    protected updateParentOnChildComplete(item: TestItem, childState: TestResultState): void {
+        const parent: TestItem | undefined = item.parent;
+        if (!parent) {
+            return;
+        }
+
+        const parentState: ParentItemState | undefined = this.parentStates.get(parent);
+        if (!parentState) {
+            return;
+        }
+
+        // Consider failed or errored tests as failures for the parent
+        if (childState === TestResultState.Failed ||
+            childState === TestResultState.Errored) {
+            parentState.hasFailure = true;
+        }
+
+        parentState.childrenCompleted++;
+
+        // Check if all children have completed
+        if (parentState.childrenCompleted >= parentState.childrenTotal && parentState.childrenTotal > 0) {
+            if (parentState.hasFailure) {
+                this.testContext.testRun.failed(parent, []);
+            } else {
+                this.testContext.testRun.passed(parent);
+            }
+        }
+    }
+}
+
+interface ParentItemState {
+    started: boolean;
+    childrenTotal: number;
+    childrenCompleted: number;
+    hasFailure: boolean;
 }

--- a/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
+++ b/src/runners/junitRunner/JUnitRunnerResultAnalyzer.ts
@@ -65,9 +65,11 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
             if (!item) {
                 return;
             }
+            this.initializeParentState(item, this.triggeredTestsMapping);
             this.setCurrentState(item, TestResultState.Running, 0);
             this.setDurationAtStart(this.getCurrentState(item));
             setTestState(this.testContext.testRun, item, this.getCurrentState(item).resultState);
+            this.updateParentOnChildStart(item);
         } else if (data.startsWith(MessageId.TestEnd)) {
             const item: TestItem | undefined = this.getTestItem(data.substr(MessageId.TestEnd.length));
             if (!item) {
@@ -77,6 +79,10 @@ export class JUnitRunnerResultAnalyzer extends RunnerResultAnalyzer {
             this.calcDurationAtEnd(currentState);
             this.determineResultStateAtEnd(data, currentState);
             setTestState(this.testContext.testRun, item, currentState.resultState, undefined, currentState.duration);
+            const itemData: ITestItemData | undefined = dataCache.get(item);
+            if (itemData?.testLevel === TestLevel.Method) {
+                this.updateParentOnChildComplete(item, currentState.resultState);
+            }
         } else if (data.startsWith(MessageId.TestFailed)) {
             const item: TestItem | undefined = this.getTestItem(data.substr(MessageId.TestFailed.length));
             if (!item) {


### PR DESCRIPTION
Test class/package status doesn't update until the end of the full test run: 
https://github.com/user-attachments/assets/2bc8c942-b407-447b-9c10-9d84c5403040

With this PR, completed tests update their parent node status, making updates/progress less frustrating:
https://github.com/user-attachments/assets/527e83da-0837-44a9-afa3-927aaa035741

