### PR TITLE
fix: use listen(0) for OS auto-port-allocation instead of getPort

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -18,7 +18,6 @@ This project incorporates components from the projects listed below. The origina
 11. lodash/lodash (https://github.com/lodash/lodash)
 12. microsoft/vscode-languageserver-node (https://github.com/microsoft/vscode-languageserver-node)
 13. ota4j-team/opentest4j (https://github.com/ota4j-team/opentest4j)
-14. sindresorhus/get-port (https://github.com/sindresorhus/get-port)
 
 %% Apache Commons Lang NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -1400,17 +1399,3 @@ END OF microsoft/vscode-languageserver-node NOTICES AND INFORMATION
    limitations under the License.
 =========================================
 END OF ota4j-team/opentest4j NOTICES AND INFORMATION
-
-%% sindresorhus/get-port NOTICES AND INFORMATION BEGIN HERE
-=========================================
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=========================================
-END OF sindresorhus/get-port NOTICES AND INFORMATION

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "0.45.0",
             "dependencies": {
                 "fs-extra": "^10.1.0",
-                "get-port": "^4.2.0",
                 "iconv-lite": "^0.6.3",
                 "lodash": "^4.18.1",
                 "lru-cache": "^7.17.0",
@@ -2129,14 +2128,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-port": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
-            "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/get-proto": {

--- a/package.json
+++ b/package.json
@@ -571,7 +571,6 @@
     },
     "dependencies": {
         "fs-extra": "^10.1.0",
-        "get-port": "^4.2.0",
         "iconv-lite": "^0.6.3",
         "lodash": "^4.18.1",
         "lru-cache": "^7.17.0",

--- a/src/runners/baseRunner/BaseRunner.ts
+++ b/src/runners/baseRunner/BaseRunner.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import getPort from 'get-port';
 import * as iconv from 'iconv-lite';
 import { AddressInfo, createServer, Server, Socket } from 'net';
 import * as os from 'os';
@@ -133,10 +132,13 @@ export abstract class BaseRunner implements ITestRunnerInternal {
 
     protected async startSocketServer(): Promise<void> {
         this.server = createServer();
-        const socketPort: number = await getPort();
         await new Promise<void>((resolve: () => void): void => {
-            this.server.listen(socketPort, Configurations.LOCAL_HOST, resolve);
+            this.server.listen(0, Configurations.LOCAL_HOST, resolve);
         });
+    }
+
+    public getServerAddress(): AddressInfo | string | null {
+        return this.server?.address() ?? null;
     }
 
     protected getRunnerCommandParams(): string[] {

--- a/test/suite/baseRunner.test.ts
+++ b/test/suite/baseRunner.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+'use strict';
+
+import * as assert from 'assert';
+import { AddressInfo } from 'net';
+import { BaseRunner } from '../../src/runners/baseRunner/BaseRunner';
+import { RunnerResultAnalyzer } from '../../src/runners/baseRunner/RunnerResultAnalyzer';
+import { IRunTestContext, TestKind } from '../../src/java-test-runner.api';
+
+class TestableBaseRunner extends BaseRunner {
+    protected getAnalyzer(): RunnerResultAnalyzer {
+        return {} as RunnerResultAnalyzer;
+    }
+}
+
+suite('BaseRunner Tests', () => {
+
+    suite('startSocketServer', () => {
+        test('server starts and listens on a valid auto-assigned port', async () => {
+            const runner = new TestableBaseRunner({
+                kind: TestKind.JUnit,
+                isDebug: false,
+                projectName: 'test-project',
+                testItems: [],
+                testRun: {} as any,
+                workspaceFolder: {} as any,
+            } as IRunTestContext);
+
+            await runner.setup();
+
+            try {
+                const address = runner.getServerAddress() as AddressInfo;
+                assert.ok(address, 'server should have an address');
+                assert.ok(address.port > 0, `server port should be > 0, got ${address.port}`);
+                assert.strictEqual(address.family, 'IPv4', 'server should be IPv4');
+            } finally {
+                await runner.tearDown();
+            }
+        });
+
+        test('getApplicationArgs returns the auto-assigned port as first argument', async () => {
+            const runner = new TestableBaseRunner({
+                kind: TestKind.JUnit,
+                isDebug: false,
+                projectName: 'test-project',
+                testItems: [],
+                testRun: {} as any,
+                workspaceFolder: {} as any,
+            } as IRunTestContext);
+
+            await runner.setup();
+
+            try {
+                const args = runner.getApplicationArgs();
+                assert.ok(args.length > 0, 'application args should not be empty');
+                const portArg = args[0];
+                const port = parseInt(portArg, 10);
+                assert.ok(port > 0, `port in args should be > 0, got ${port}`);
+            } finally {
+                await runner.tearDown();
+            }
+        });
+    });
+});


### PR DESCRIPTION
fix: use listen(0) for OS auto-port-allocation instead of getPort pre-selection

In WSL/Windows port environments, the two-step pattern of reserving a
      port with getPort() then rebinding to it caused massive EADDRINUSE
      failures (~96 out of 100 attempts). Replacing with
server.listen(0)
      lets the OS auto-assign a free port in a single step, achieving 0
      failures in the same environment.
Fixes #1854