### PR TITLE
Fix JUnit 5 launch failure with standalone/fat Multi-Release JARs

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -60,9 +61,56 @@ public class JUnitLaunchConfigurationDelegate extends org.eclipse.jdt.junit.laun
     private static final Set<String> testNameArgs = new HashSet<>(
         Arrays.asList("-test", "-classNames", "-packageNameFile", "-testNameFile"));
 
+    // org.eclipse.jdt.internal.junit.IJUnitStatusConstants.ERR_JUNIT_NOT_ON_PATH
+    private static final int ERR_JUNIT_NOT_ON_PATH = 20006;
+
     public JUnitLaunchConfigurationDelegate(Argument args) {
         super();
         this.args = args;
+    }
+
+    /**
+     * Workaround for https://github.com/redhat-developer/vscode-java/issues/4396
+     *
+     * Eclipse JDT's CoreTestSearchEngine.hasJUnit5TestAnnotation() was changed to use
+     * NameLookup.findType() with ACCEPT_ANNOTATIONS + checkRestrictions=true, which fails
+     * to find @Testable in standalone/fat Multi-Release JARs
+     * (e.g., junit-platform-console-standalone-1.13.4.jar).
+     *
+     * This override calls the superclass preLaunchCheck() normally, but catches the specific
+     * "JUnit not on path" false negative and falls back to project.findType() which works.
+     *
+     * See upstream: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2959
+     */
+    @Override
+    protected void preLaunchCheck(ILaunchConfiguration configuration, ILaunch launch,
+            IProgressMonitor monitor) throws CoreException {
+        try {
+            super.preLaunchCheck(configuration, launch, monitor);
+        } catch (CoreException e) {
+            if (e.getStatus().getCode() == ERR_JUNIT_NOT_ON_PATH) {
+                final IJavaProject javaProject = getJavaProject(configuration);
+                if (javaProject != null && hasJUnitOnClasspath(javaProject)) {
+                    // JUnit is actually on the classpath via a standalone/fat JAR,
+                    // suppress the false negative from the upstream check.
+                    return;
+                }
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Fallback check using the old-style project.findType() which correctly resolves
+     * types inside standalone/fat Multi-Release JARs.
+     */
+    private boolean hasJUnitOnClasspath(IJavaProject javaProject) {
+        try {
+            return javaProject.findType("org.junit.jupiter.api.Test") != null
+                || javaProject.findType("org.junit.platform.commons.annotation.Testable") != null;
+        } catch (JavaModelException e) {
+            return false;
+        }
     }
 
     public Response<JUnitLaunchArguments> getJUnitLaunchArguments(ILaunchConfiguration configuration, String mode,


### PR DESCRIPTION
## Summary

Fix JUnit 5 test launch failure when using standalone/fat Multi-Release JARs such as `junit-platform-console-standalone-1.13.4.jar`.

## Problem

Since the upstream Eclipse JDT change ([eclipse-jdt/eclipse.jdt.ui@0edde57](https://github.com/eclipse-jdt/eclipse.jdt.ui/commit/0edde57)), `CoreTestSearchEngine.findAnnotations()` uses `NameLookup.findType()` with `ACCEPT_ANNOTATIONS` + `checkRestrictions=true` instead of the old `IJavaProject.findType()`. This causes `@Testable` to not be found in standalone/fat Multi-Release JARs, resulting in:

`
Cannot find 'org.junit.platform.commons.annotation.Testable' on project build path.
JUnit 5 tests can only be run if JUnit 5 is on the build path.
`

## Fix

Override `preLaunchCheck()` in our `JUnitLaunchConfigurationDelegate` to:
1. Call `super.preLaunchCheck()` normally (preserving all existing validation)
2. Catch only the specific `ERR_JUNIT_NOT_ON_PATH` (20006) error
3. Fall back to `IJavaProject.findType()` to verify JUnit is actually on the classpath
4. Only suppress the error if the fallback confirms JUnit is present; otherwise re-throw

This is a **narrow, targeted workaround** — all other validation from the superclass is preserved.

## Related Issues

- Downstream: https://github.com/redhat-developer/vscode-java/issues/4396
- Upstream bug filed: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2959