### PR TITLE
fix: use maven-metadata.xml to look up latest test framework version

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -47,6 +47,7 @@ jobs:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const title = '[health-check] Maven Central data source check failed';
+            const labelName = 'ci-health';
             const body = [
               'The scheduled health check for the Maven Central data sources used by',
               '`scripts/checkVersionSources.js` failed.',
@@ -64,11 +65,29 @@ jobs:
               'Please investigate before users start hitting the broken download.',
             ].join('\n');
 
+            // Ensure the label exists so issues.create({ labels: [...] }) does not 422.
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+                color: 'd93f0b',
+                description: 'Automated CI health-check failure',
+              });
+              core.info(`Created label "${labelName}".`);
+            } catch (err) {
+              if (err.status === 422) {
+                core.info(`Label "${labelName}" already exists.`);
+              } else {
+                throw err;
+              }
+            }
+
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'ci-health',
+              labels: labelName,
               per_page: 100,
             });
             const alreadyOpen = existing.find((issue) => issue.title === title);
@@ -86,7 +105,7 @@ jobs:
                 repo: context.repo.repo,
                 title,
                 body,
-                labels: ['ci-health'],
+                labels: [labelName],
               });
               core.info(`Opened issue #${created.number}.`);
             }

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,92 @@
+name: Health Check - Maven Central Data Sources
+
+# Verifies that the upstream Maven Central data sources used by the
+# "Enable Java Tests" download flow (see scripts/checkVersionSources.js)
+# are still healthy. This catches situations like microsoft/vscode-java-test#1866,
+# where the legacy search.maven.org Solr index was silently frozen and
+# kept returning a pre-release as the "latest" stable version.
+#
+# - Runs on every PR and push to main so a code change cannot break the lookup.
+# - Runs weekly so purely upstream changes are caught within days.
+# - Can be triggered manually from the Actions tab.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Monday 09:00 UTC.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-version-sources:
+    name: Check Maven Central version sources
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run version source health check
+        run: node scripts/checkVersionSources.js
+
+      - name: Open issue on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = '[health-check] Maven Central data source check failed';
+            const body = [
+              'The scheduled health check for the Maven Central data sources used by',
+              '`scripts/checkVersionSources.js` failed.',
+              '',
+              `Failed run: ${runUrl}`,
+              '',
+              'This typically means one of the following:',
+              '- An upstream `maven-metadata.xml` is no longer reachable (HTTP 4xx/5xx).',
+              '- An upstream `<release>` tag has drifted to a pre-release version',
+              '  (e.g. `-M3`, `-RC1`, `-beta-1`).',
+              '- A jar download URL is no longer reachable.',
+              '',
+              'See microsoft/vscode-java-test#1866 for the original failure mode.',
+              '',
+              'Please investigate before users start hitting the broken download.',
+            ].join('\n');
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci-health',
+              per_page: 100,
+            });
+            const alreadyOpen = existing.find((issue) => issue.title === title);
+            if (alreadyOpen) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: alreadyOpen.number,
+                body: `Health check failed again. Run: ${runUrl}`,
+              });
+              core.info(`Commented on existing issue #${alreadyOpen.number}.`);
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['ci-health'],
+              });
+              core.info(`Opened issue #${created.number}.`);
+            }

--- a/scripts/checkVersionSources.js
+++ b/scripts/checkVersionSources.js
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Health check for the Maven Central data sources that
+ * `src/commands/testDependenciesCommands.ts` relies on for the
+ * "Enable Java Tests" download flow.
+ *
+ * For every artifact that vscode-java-test fetches at runtime, this script:
+ *
+ *   1. Downloads the artifact's `maven-metadata.xml` from repo1.maven.org.
+ *   2. Extracts the `<release>` element and asserts it is a stable version
+ *      (dot-separated digits only — no `-M3`, `-RC1`, `-beta-1`, etc.).
+ *   3. Issues an HTTP HEAD against the resolved `.jar` download URL and
+ *      asserts a 2xx response.
+ *
+ * This guards against silent upstream drift, e.g.
+ *   - the data source moving / being deprecated (microsoft/vscode-java-test#1866,
+ *     where the legacy search.maven.org Solr index was frozen for ~a year
+ *     and kept returning a milestone build as the "latest"),
+ *   - a maintainer accidentally publishing a pre-release as `<release>`,
+ *   - the jar layout under repo1.maven.org changing.
+ *
+ * Runs on PRs (so a code change that breaks the lookup never lands) and
+ * on a weekly cron (so a purely upstream change is caught within days
+ * instead of months).
+ *
+ * Pure Node, no dependencies — works before `npm install` runs.
+ */
+
+'use strict';
+
+const ARTIFACTS = [
+    // JUnit 5 / Jupiter (the path that originally surfaced #1866).
+    { groupId: 'org.junit.platform', artifactId: 'junit-platform-console-standalone' },
+
+    // JUnit 4 + its hamcrest-core dependency.
+    { groupId: 'junit', artifactId: 'junit' },
+    // hamcrest-core is pinned to 1.3 in the extension; verify both that 1.3
+    // still resolves and that the artifact metadata is reachable.
+    { groupId: 'org.hamcrest', artifactId: 'hamcrest-core', pinnedVersion: '1.3' },
+
+    // TestNG + its transitive deps that we ship.
+    { groupId: 'org.testng', artifactId: 'testng' },
+    { groupId: 'com.beust', artifactId: 'jcommander' },
+    { groupId: 'org.slf4j', artifactId: 'slf4j-api' },
+];
+
+const MAX_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 2000;
+const REQUEST_TIMEOUT_MS = 15000;
+
+const STABLE_VERSION_REGEX = /^\d+(\.\d+)*$/;
+
+function groupPath(groupId) {
+    return groupId.split('.').join('/');
+}
+
+function metadataUrl(groupId, artifactId) {
+    return `https://repo1.maven.org/maven2/${groupPath(groupId)}/${artifactId}/maven-metadata.xml`;
+}
+
+function jarUrl(groupId, artifactId, version) {
+    return `https://repo1.maven.org/maven2/${groupPath(groupId)}/${artifactId}/${version}/${artifactId}-${version}.jar`;
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(url, init) {
+    let lastError;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+        try {
+            const response = await fetch(url, { ...init, signal: controller.signal });
+            clearTimeout(timer);
+            return response;
+        } catch (err) {
+            clearTimeout(timer);
+            lastError = err;
+            if (attempt < MAX_ATTEMPTS) {
+                const delay = RETRY_BASE_DELAY_MS * attempt;
+                console.warn(`  ! attempt ${attempt}/${MAX_ATTEMPTS} for ${url} failed: ${err.message}. Retrying in ${delay}ms...`);
+                await sleep(delay);
+            }
+        }
+    }
+    throw lastError;
+}
+
+function parseLatestStableVersion(xml) {
+    const releaseMatch = xml.match(/<release>([^<]+)<\/release>/);
+    if (releaseMatch && STABLE_VERSION_REGEX.test(releaseMatch[1])) {
+        return releaseMatch[1];
+    }
+    const versions = [];
+    const versionRegex = /<version>([^<]+)<\/version>/g;
+    let match;
+    while ((match = versionRegex.exec(xml)) !== null) {
+        versions.push(match[1]);
+    }
+    for (let i = versions.length - 1; i >= 0; i--) {
+        if (STABLE_VERSION_REGEX.test(versions[i])) {
+            return versions[i];
+        }
+    }
+    return undefined;
+}
+
+async function checkArtifact(artifact) {
+    const { groupId, artifactId, pinnedVersion } = artifact;
+    console.log(`\n== ${groupId}:${artifactId} ==`);
+
+    const metaUrl = metadataUrl(groupId, artifactId);
+    console.log(`  GET  ${metaUrl}`);
+    const metaResponse = await fetchWithRetry(metaUrl);
+    if (!metaResponse.ok) {
+        throw new Error(`maven-metadata.xml returned HTTP ${metaResponse.status} ${metaResponse.statusText}`);
+    }
+    const xml = await metaResponse.text();
+
+    const releaseMatch = xml.match(/<release>([^<]+)<\/release>/);
+    if (releaseMatch) {
+        const rawRelease = releaseMatch[1];
+        if (!STABLE_VERSION_REGEX.test(rawRelease)) {
+            // Production falls back to the <versions> list when <release>
+            // points to a pre-release, so this is non-fatal — but still
+            // noisy enough to be worth surfacing in the log.
+            console.warn(`  ! <release> is a pre-release: "${rawRelease}". Falling back to <versions> scan.`);
+        }
+    } else {
+        console.warn('  ! <release> tag missing — relying entirely on <versions> fallback.');
+    }
+
+    const latestStable = parseLatestStableVersion(xml);
+    if (!latestStable) {
+        throw new Error('No stable version found in maven-metadata.xml.');
+    }
+    console.log(`  ok   latest stable version = ${latestStable}`);
+
+    const versionsToProbe = pinnedVersion && pinnedVersion !== latestStable
+        ? [latestStable, pinnedVersion]
+        : [latestStable];
+
+    for (const version of versionsToProbe) {
+        const downloadUrl = jarUrl(groupId, artifactId, version);
+        console.log(`  HEAD ${downloadUrl}`);
+        const headResponse = await fetchWithRetry(downloadUrl, { method: 'HEAD' });
+        if (!headResponse.ok) {
+            throw new Error(`jar HEAD returned HTTP ${headResponse.status} ${headResponse.statusText} for ${downloadUrl}`);
+        }
+        console.log(`  ok   jar reachable (HTTP ${headResponse.status})`);
+    }
+}
+
+async function main() {
+    console.log('Checking Maven Central data sources for vscode-java-test...');
+    const failures = [];
+    for (const artifact of ARTIFACTS) {
+        try {
+            await checkArtifact(artifact);
+        } catch (err) {
+            failures.push({ artifact, error: err });
+            console.error(`  FAIL ${artifact.groupId}:${artifact.artifactId} — ${err.message}`);
+        }
+    }
+
+    console.log('\n----');
+    if (failures.length === 0) {
+        console.log(`All ${ARTIFACTS.length} artifacts healthy.`);
+        return;
+    }
+
+    console.error(`${failures.length} of ${ARTIFACTS.length} artifact checks FAILED:`);
+    for (const { artifact, error } of failures) {
+        console.error(`  - ${artifact.groupId}:${artifact.artifactId}: ${error.message}`);
+    }
+    process.exit(1);
+}
+
+main().catch((err) => {
+    console.error('Unexpected error:', err);
+    process.exit(1);
+});

--- a/scripts/checkVersionSources.js
+++ b/scripts/checkVersionSources.js
@@ -32,7 +32,20 @@
 
 const ARTIFACTS = [
     // JUnit 5 / Jupiter (the path that originally surfaced #1866).
-    { groupId: 'org.junit.platform', artifactId: 'junit-platform-console-standalone' },
+    // The console-standalone GAV publishes two coexisting release lines
+    // (1.x for legacy Jupiter 5, 6.x for Jupiter 6). The extension routes
+    // TestKind.JUnit5 to the 1.x line and TestKind.JUnit6 to the 6.x line,
+    // so the health check covers both.
+    {
+        groupId: 'org.junit.platform',
+        artifactId: 'junit-platform-console-standalone',
+        versionLine: '1',
+    },
+    {
+        groupId: 'org.junit.platform',
+        artifactId: 'junit-platform-console-standalone',
+        versionLine: '6',
+    },
 
     // JUnit 4 + its hamcrest-core dependency.
     { groupId: 'junit', artifactId: 'junit' },
@@ -90,11 +103,16 @@ async function fetchWithRetry(url, init) {
     throw lastError;
 }
 
-function parseLatestStableVersion(xml) {
-    const releaseMatch = xml.match(/<release>([^<]+)<\/release>/);
-    if (releaseMatch && STABLE_VERSION_REGEX.test(releaseMatch[1])) {
-        return releaseMatch[1];
+function parseLatestStableVersion(xml, versionLine) {
+    if (versionLine === undefined) {
+        const releaseMatch = xml.match(/<release>([^<]+)<\/release>/);
+        if (releaseMatch && STABLE_VERSION_REGEX.test(releaseMatch[1])) {
+            return releaseMatch[1];
+        }
     }
+    const lineRegex = versionLine !== undefined
+        ? new RegExp(`^${versionLine.replace(/\./g, '\\.')}(\\.|$)`)
+        : undefined;
     const versions = [];
     const versionRegex = /<version>([^<]+)<\/version>/g;
     let match;
@@ -102,16 +120,22 @@ function parseLatestStableVersion(xml) {
         versions.push(match[1]);
     }
     for (let i = versions.length - 1; i >= 0; i--) {
-        if (STABLE_VERSION_REGEX.test(versions[i])) {
-            return versions[i];
+        const candidate = versions[i];
+        if (!STABLE_VERSION_REGEX.test(candidate)) {
+            continue;
         }
+        if (lineRegex && !lineRegex.test(candidate)) {
+            continue;
+        }
+        return candidate;
     }
     return undefined;
 }
 
 async function checkArtifact(artifact) {
-    const { groupId, artifactId, pinnedVersion } = artifact;
-    console.log(`\n== ${groupId}:${artifactId} ==`);
+    const { groupId, artifactId, pinnedVersion, versionLine } = artifact;
+    const scope = versionLine ? ` (${versionLine}.x line)` : '';
+    console.log(`\n== ${groupId}:${artifactId}${scope} ==`);
 
     const metaUrl = metadataUrl(groupId, artifactId);
     console.log(`  GET  ${metaUrl}`);
@@ -121,24 +145,23 @@ async function checkArtifact(artifact) {
     }
     const xml = await metaResponse.text();
 
-    const releaseMatch = xml.match(/<release>([^<]+)<\/release>/);
-    if (releaseMatch) {
-        const rawRelease = releaseMatch[1];
-        if (!STABLE_VERSION_REGEX.test(rawRelease)) {
-            // Production falls back to the <versions> list when <release>
-            // points to a pre-release, so this is non-fatal — but still
-            // noisy enough to be worth surfacing in the log.
-            console.warn(`  ! <release> is a pre-release: "${rawRelease}". Falling back to <versions> scan.`);
+    if (versionLine === undefined) {
+        const releaseMatch = xml.match(/<release>([^<]+)<\/release>/);
+        if (releaseMatch) {
+            const rawRelease = releaseMatch[1];
+            if (!STABLE_VERSION_REGEX.test(rawRelease)) {
+                console.warn(`  ! <release> is a pre-release: "${rawRelease}". Falling back to <versions> scan.`);
+            }
+        } else {
+            console.warn('  ! <release> tag missing — relying entirely on <versions> fallback.');
         }
-    } else {
-        console.warn('  ! <release> tag missing — relying entirely on <versions> fallback.');
     }
 
-    const latestStable = parseLatestStableVersion(xml);
+    const latestStable = parseLatestStableVersion(xml, versionLine);
     if (!latestStable) {
-        throw new Error('No stable version found in maven-metadata.xml.');
+        throw new Error(`No stable version found${scope} in maven-metadata.xml.`);
     }
-    console.log(`  ok   latest stable version = ${latestStable}`);
+    console.log(`  ok   latest stable version${scope} = ${latestStable}`);
 
     const versionsToProbe = pinnedVersion && pinnedVersion !== latestStable
         ? [latestStable, pinnedVersion]

--- a/src/commands/testDependenciesCommands.ts
+++ b/src/commands/testDependenciesCommands.ts
@@ -138,7 +138,7 @@ function getJarIds(testKind: TestKind): IArtifactMetadata[] {
             return [{
                 groupId: 'org.junit.platform',
                 artifactId: 'junit-platform-console-standalone',
-                defaultVersion: '1.9.3',
+                defaultVersion: '6.1.0',
             }];
         case TestKind.JUnit:
             return [{
@@ -172,18 +172,41 @@ function getJarIds(testKind: TestKind): IArtifactMetadata[] {
 
 async function getLatestVersion(groupId: string, artifactId: string): Promise<string | undefined> {
     try {
-        const response: any = await getHttpsAsJSON(getQueryLink(groupId, artifactId));
+        const xml: string = await getHttpsAsText(getMetadataLink(groupId, artifactId));
 
-        if (!response.response?.docs?.[0]?.latestVersion) {
-            sendError(new Error('Invalid format for the latest version response'));
-            return undefined;
+        // Prefer the <release> tag (Maven's authoritative pointer to the latest non-snapshot version).
+        const releaseMatch: RegExpMatchArray | null = xml.match(/<release>([^<]+)<\/release>/);
+        if (releaseMatch && isStableVersion(releaseMatch[1])) {
+            return releaseMatch[1];
         }
-        return response.response.docs[0].latestVersion;
+
+        // Fallback: scan <version> entries (chronologically ordered) for the newest stable version,
+        // in case <release> is missing or points to a milestone / RC.
+        const versionRegex: RegExp = /<version>([^<]+)<\/version>/g;
+        const versions: string[] = [];
+        let match: RegExpExecArray | null;
+        while ((match = versionRegex.exec(xml)) !== null) {
+            versions.push(match[1]);
+        }
+        for (let i: number = versions.length - 1; i >= 0; i--) {
+            if (isStableVersion(versions[i])) {
+                return versions[i];
+            }
+        }
+
+        sendError(new Error(`No stable version found in maven-metadata.xml for ${groupId}:${artifactId}`));
     } catch (e) {
         sendError(new Error(`Failed to fetch the latest version for ${groupId}:${artifactId}`));
     }
 
     return undefined;
+}
+
+function isStableVersion(version: string): boolean {
+    // A stable Maven version is composed solely of dot-separated numeric segments
+    // (e.g. 6.1.0, 4.13.2). Anything with a qualifier such as -M3, -RC1, -beta-1
+    // or -SNAPSHOT is treated as a pre-release.
+    return /^\d+(\.\d+)*$/.test(version);
 }
 
 async function downloadJar(
@@ -274,9 +297,9 @@ async function updateProjectSettings(projectUri: Uri, libFolder: string): Promis
     window.showInformationMessage(`Test libraries have been downloaded into '${relativePath}/'.`);
 }
 
-async function getHttpsAsJSON(link: string): Promise<any> {
+async function getHttpsAsText(link: string): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/typedef
-    const response: string = await new Promise<string>((resolve, reject) => {
+    return new Promise<string>((resolve, reject) => {
         let result: string = '';
         https.get(link, {
             headers: {
@@ -295,7 +318,6 @@ async function getHttpsAsJSON(link: string): Promise<any> {
             res.on('error', reject);
         });
     });
-    return JSON.parse(response);
 }
 
 async function getTotalBytes(url: string): Promise<number> {
@@ -315,8 +337,8 @@ async function getTotalBytes(url: string): Promise<number> {
     });
 }
 
-function getQueryLink(groupId: string, artifactId: string): string {
-    return `https://search.maven.org/solrsearch/select?q=id:%22${groupId}:${artifactId}%22&rows=1&wt=json`;
+function getMetadataLink(groupId: string, artifactId: string): string {
+    return `https://repo1.maven.org/maven2/${groupId.split('.').join('/')}/${artifactId}/maven-metadata.xml`;
 }
 
 function getDownloadLink(groupId: string, artifactId: string, version: string): string {

--- a/src/commands/testDependenciesCommands.ts
+++ b/src/commands/testDependenciesCommands.ts
@@ -78,7 +78,7 @@ async function setupUnmanagedFolder(projectUri: Uri, testKind?: TestKind): Promi
                     message: `Downloading ${jar.artifactId}.jar...`,
                 });
                 if (!jar.version) {
-                    jar.version = await getLatestVersion(jar.groupId, jar.artifactId) || jar.defaultVersion;
+                    jar.version = await getLatestVersion(jar.groupId, jar.artifactId, jar.versionLine) || jar.defaultVersion;
                 }
                 await downloadJar(libFolder, jar.groupId, jar.artifactId, jar.version, metadata.length, progress, token);
             }
@@ -135,10 +135,22 @@ async function getLibFolder(projectUri: Uri): Promise<string> {
 function getJarIds(testKind: TestKind): IArtifactMetadata[] {
     switch (testKind) {
         case TestKind.JUnit5:
+            // Pin to the JUnit Platform 1.x line. JUnit Platform 6.x ships
+            // alongside 1.x under the same GAV, but it requires a compatible
+            // JDT-LS runner; users who explicitly choose "JUnit Jupiter 5"
+            // are opting into the 1.x line and should get its newest stable.
+            return [{
+                groupId: 'org.junit.platform',
+                artifactId: 'junit-platform-console-standalone',
+                defaultVersion: '1.14.4',
+                versionLine: '1',
+            }];
+        case TestKind.JUnit6:
             return [{
                 groupId: 'org.junit.platform',
                 artifactId: 'junit-platform-console-standalone',
                 defaultVersion: '6.1.0',
+                versionLine: '6',
             }];
         case TestKind.JUnit:
             return [{
@@ -170,12 +182,17 @@ function getJarIds(testKind: TestKind): IArtifactMetadata[] {
     }
 }
 
-async function getLatestVersion(groupId: string, artifactId: string): Promise<string | undefined> {
+async function getLatestVersion(
+    groupId: string,
+    artifactId: string,
+    versionLine?: string,
+): Promise<string | undefined> {
     try {
         const xml: string = await getHttpsAsText(getMetadataLink(groupId, artifactId));
-        const version: string | undefined = parseLatestStableVersion(xml);
+        const version: string | undefined = parseLatestStableVersion(xml, versionLine);
         if (version === undefined) {
-            sendError(new Error(`No stable version found in maven-metadata.xml for ${groupId}:${artifactId}`));
+            const scope: string = versionLine ? ` in the ${versionLine}.x line` : '';
+            sendError(new Error(`No stable version found${scope} in maven-metadata.xml for ${groupId}:${artifactId}`));
         }
         return version;
     } catch (e) {
@@ -186,12 +203,22 @@ async function getLatestVersion(groupId: string, artifactId: string): Promise<st
     return undefined;
 }
 
-function parseLatestStableVersion(xml: string): string | undefined {
-    // Prefer the <release> tag (Maven's authoritative pointer to the latest non-snapshot version).
-    const releaseMatch: RegExpMatchArray | null = xml.match(/<release>([^<]+)<\/release>/);
-    if (releaseMatch && isStableVersion(releaseMatch[1])) {
-        return releaseMatch[1];
+function parseLatestStableVersion(xml: string, versionLine?: string): string | undefined {
+    // When the caller pins a version line (e.g. '1' for the JUnit Platform 1.x line),
+    // skip the <release> shortcut — it points to the globally latest stable, which may
+    // be in a different line. Scan <version> entries directly for the newest stable
+    // version whose major segment matches.
+    if (versionLine === undefined) {
+        // Prefer the <release> tag (Maven's authoritative pointer to the latest non-snapshot version).
+        const releaseMatch: RegExpMatchArray | null = xml.match(/<release>([^<]+)<\/release>/);
+        if (releaseMatch && isStableVersion(releaseMatch[1])) {
+            return releaseMatch[1];
+        }
     }
+
+    const lineRegex: RegExp | undefined = versionLine !== undefined
+        ? new RegExp(`^${versionLine.replace(/\./g, '\\.')}(\\.|$)`)
+        : undefined;
 
     // Fallback: scan <version> entries (chronologically ordered) for the newest stable version,
     // in case <release> is missing or points to a milestone / RC.
@@ -202,9 +229,14 @@ function parseLatestStableVersion(xml: string): string | undefined {
         versions.push(match[1]);
     }
     for (let i: number = versions.length - 1; i >= 0; i--) {
-        if (isStableVersion(versions[i])) {
-            return versions[i];
+        const candidate: string = versions[i];
+        if (!isStableVersion(candidate)) {
+            continue;
         }
+        if (lineRegex && !lineRegex.test(candidate)) {
+            continue;
+        }
+        return candidate;
     }
 
     return undefined;
@@ -366,6 +398,13 @@ interface IArtifactMetadata {
     artifactId: string;
     version?: string;
     defaultVersion: string;
+    /**
+     * If set, constrains getLatestVersion() to the newest stable version whose
+     * leading segment matches this string. Used when an artifact maintains
+     * multiple coexisting release lines under the same GAV (e.g.
+     * junit-platform-console-standalone publishes both the 1.x and 6.x lines).
+     */
+    versionLine?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/typedef

--- a/src/commands/testDependenciesCommands.ts
+++ b/src/commands/testDependenciesCommands.ts
@@ -179,7 +179,8 @@ async function getLatestVersion(groupId: string, artifactId: string): Promise<st
         }
         return version;
     } catch (e) {
-        sendError(new Error(`Failed to fetch the latest version for ${groupId}:${artifactId}`));
+        const detail: string = (e instanceof Error) ? e.message : String(e);
+        sendError(new Error(`Failed to fetch the latest version for ${groupId}:${artifactId}: ${detail}`));
     }
 
     return undefined;
@@ -308,13 +309,17 @@ async function getHttpsAsText(link: string): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/typedef
     return new Promise<string>((resolve, reject) => {
         let result: string = '';
-        https.get(link, {
+        const req: ClientRequest = https.get(link, {
             headers: {
                 'User-Agent': 'vscode-JavaTestRunner/0.1',
             },
         }, (res: http.IncomingMessage) => {
-            if (res.statusCode !== 200) {
-                return reject(new Error(`Request failed with status code: ${res.statusCode}`));
+            const statusCode: number = res.statusCode ?? 0;
+            if (statusCode < 200 || statusCode >= 300) {
+                // Drain the socket so it can be returned to the agent pool
+                // instead of hanging until the server times us out.
+                res.resume();
+                return reject(new Error(`Request to ${link} failed with status code: ${statusCode}`));
             }
             res.on('data', (chunk: any) => {
                 result = result.concat(chunk.toString());
@@ -324,6 +329,10 @@ async function getHttpsAsText(link: string): Promise<string> {
             });
             res.on('error', reject);
         });
+        // https.get returns a ClientRequest that emits 'error' for failures that
+        // happen before any response is received (DNS, TCP reset, TLS handshake,
+        // etc.). Without this listener the promise would hang forever.
+        req.on('error', reject);
     });
 }
 

--- a/src/commands/testDependenciesCommands.ts
+++ b/src/commands/testDependenciesCommands.ts
@@ -173,30 +173,37 @@ function getJarIds(testKind: TestKind): IArtifactMetadata[] {
 async function getLatestVersion(groupId: string, artifactId: string): Promise<string | undefined> {
     try {
         const xml: string = await getHttpsAsText(getMetadataLink(groupId, artifactId));
-
-        // Prefer the <release> tag (Maven's authoritative pointer to the latest non-snapshot version).
-        const releaseMatch: RegExpMatchArray | null = xml.match(/<release>([^<]+)<\/release>/);
-        if (releaseMatch && isStableVersion(releaseMatch[1])) {
-            return releaseMatch[1];
+        const version: string | undefined = parseLatestStableVersion(xml);
+        if (version === undefined) {
+            sendError(new Error(`No stable version found in maven-metadata.xml for ${groupId}:${artifactId}`));
         }
-
-        // Fallback: scan <version> entries (chronologically ordered) for the newest stable version,
-        // in case <release> is missing or points to a milestone / RC.
-        const versionRegex: RegExp = /<version>([^<]+)<\/version>/g;
-        const versions: string[] = [];
-        let match: RegExpExecArray | null;
-        while ((match = versionRegex.exec(xml)) !== null) {
-            versions.push(match[1]);
-        }
-        for (let i: number = versions.length - 1; i >= 0; i--) {
-            if (isStableVersion(versions[i])) {
-                return versions[i];
-            }
-        }
-
-        sendError(new Error(`No stable version found in maven-metadata.xml for ${groupId}:${artifactId}`));
+        return version;
     } catch (e) {
         sendError(new Error(`Failed to fetch the latest version for ${groupId}:${artifactId}`));
+    }
+
+    return undefined;
+}
+
+function parseLatestStableVersion(xml: string): string | undefined {
+    // Prefer the <release> tag (Maven's authoritative pointer to the latest non-snapshot version).
+    const releaseMatch: RegExpMatchArray | null = xml.match(/<release>([^<]+)<\/release>/);
+    if (releaseMatch && isStableVersion(releaseMatch[1])) {
+        return releaseMatch[1];
+    }
+
+    // Fallback: scan <version> entries (chronologically ordered) for the newest stable version,
+    // in case <release> is missing or points to a milestone / RC.
+    const versionRegex: RegExp = /<version>([^<]+)<\/version>/g;
+    const versions: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = versionRegex.exec(xml)) !== null) {
+        versions.push(match[1]);
+    }
+    for (let i: number = versions.length - 1; i >= 0; i--) {
+        if (isStableVersion(versions[i])) {
+            return versions[i];
+        }
     }
 
     return undefined;
@@ -350,4 +357,10 @@ interface IArtifactMetadata {
     artifactId: string;
     version?: string;
     defaultVersion: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/typedef
+export const exportedForTesting = {
+    parseLatestStableVersion,
+    isStableVersion,
 }

--- a/test/suite/testDependenciesCommands.test.ts
+++ b/test/suite/testDependenciesCommands.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+'use strict';
+
+import * as assert from 'assert';
+import { exportedForTesting } from '../../src/commands/testDependenciesCommands';
+
+// tslint:disable: only-arrow-functions
+// tslint:disable: no-object-literal-type-assertion
+
+const { parseLatestStableVersion, isStableVersion } = exportedForTesting;
+
+suite('testDependenciesCommands - version source parsing', () => {
+
+    suite('isStableVersion', () => {
+        test('accepts pure dot-separated numeric versions', () => {
+            assert.strictEqual(isStableVersion('6.1.0'), true);
+            assert.strictEqual(isStableVersion('4.13.2'), true);
+            assert.strictEqual(isStableVersion('1.14.4'), true);
+            assert.strictEqual(isStableVersion('7'), true);
+            assert.strictEqual(isStableVersion('1.0.0.0'), true);
+        });
+
+        test('rejects milestone, RC, beta, snapshot and other qualified versions', () => {
+            assert.strictEqual(isStableVersion('1.13.0-M3'), false);
+            assert.strictEqual(isStableVersion('1.0.0-RC1'), false);
+            assert.strictEqual(isStableVersion('4.13-beta-1'), false);
+            assert.strictEqual(isStableVersion('4.13-rc-2'), false);
+            assert.strictEqual(isStableVersion('1.0-SNAPSHOT'), false);
+            assert.strictEqual(isStableVersion('5.0.0-alpha'), false);
+            assert.strictEqual(isStableVersion('6.0.0.preview'), false);
+            assert.strictEqual(isStableVersion(''), false);
+        });
+    });
+
+    suite('parseLatestStableVersion', () => {
+        test('returns <release> when it is a stable version', () => {
+            const xml: string = `
+                <metadata>
+                  <versioning>
+                    <release>6.1.0</release>
+                    <versions>
+                      <version>6.0.0</version>
+                      <version>6.1.0</version>
+                    </versions>
+                  </versioning>
+                </metadata>`;
+            assert.strictEqual(parseLatestStableVersion(xml), '6.1.0');
+        });
+
+        test('falls back to the newest stable <version> when <release> is a milestone', () => {
+            // This is the exact shape that would have appeared had the upstream <release>
+            // pointer drifted to a milestone — the same failure mode the stale
+            // search.maven.org Solr index exhibited for years.
+            const xml: string = `
+                <metadata>
+                  <versioning>
+                    <release>1.13.0-M3</release>
+                    <versions>
+                      <version>1.13.0-M1</version>
+                      <version>1.13.0-M2</version>
+                      <version>1.13.0-M3</version>
+                      <version>1.14.0</version>
+                      <version>1.14.4</version>
+                    </versions>
+                  </versioning>
+                </metadata>`;
+            assert.strictEqual(parseLatestStableVersion(xml), '1.14.4');
+        });
+
+        test('returns the newest stable <version> when <release> is missing', () => {
+            const xml: string = `
+                <metadata>
+                  <versioning>
+                    <versions>
+                      <version>4.13-beta-1</version>
+                      <version>4.13</version>
+                      <version>4.13.1</version>
+                      <version>4.13.2</version>
+                    </versions>
+                  </versioning>
+                </metadata>`;
+            assert.strictEqual(parseLatestStableVersion(xml), '4.13.2');
+        });
+
+        test('skips trailing pre-releases and picks the most recent stable below them', () => {
+            // <versions> ordering follows publication time, so the newest entry can be a
+            // pre-release. The parser must walk backwards past it to the latest stable.
+            const xml: string = `
+                <metadata>
+                  <versioning>
+                    <versions>
+                      <version>6.0.0</version>
+                      <version>6.1.0</version>
+                      <version>6.2.0-M1</version>
+                      <version>6.2.0-RC1</version>
+                    </versions>
+                  </versioning>
+                </metadata>`;
+            assert.strictEqual(parseLatestStableVersion(xml), '6.1.0');
+        });
+
+        test('returns undefined when no stable version exists anywhere', () => {
+            const xml: string = `
+                <metadata>
+                  <versioning>
+                    <release>1.0.0-RC1</release>
+                    <versions>
+                      <version>1.0.0-M1</version>
+                      <version>1.0.0-RC1</version>
+                    </versions>
+                  </versioning>
+                </metadata>`;
+            assert.strictEqual(parseLatestStableVersion(xml), undefined);
+        });
+
+        test('returns undefined for malformed input', () => {
+            assert.strictEqual(parseLatestStableVersion(''), undefined);
+            assert.strictEqual(parseLatestStableVersion('<html>404 Not Found</html>'), undefined);
+        });
+    });
+});

--- a/test/suite/testDependenciesCommands.test.ts
+++ b/test/suite/testDependenciesCommands.test.ts
@@ -120,4 +120,74 @@ suite('testDependenciesCommands - version source parsing', () => {
             assert.strictEqual(parseLatestStableVersion('<html>404 Not Found</html>'), undefined);
         });
     });
+
+    suite('parseLatestStableVersion with versionLine', () => {
+        // Real-world shape: junit-platform-console-standalone publishes both the
+        // 1.x and 6.x lines under the same GAV, with <release> tracking the
+        // globally newest stable (6.x).
+        const COEXISTING_LINES_XML: string = `
+            <metadata>
+              <versioning>
+                <release>6.1.0</release>
+                <versions>
+                  <version>1.13.0</version>
+                  <version>1.14.0-RC1</version>
+                  <version>1.14.0</version>
+                  <version>1.14.4</version>
+                  <version>6.0.0-RC1</version>
+                  <version>6.0.0</version>
+                  <version>6.1.0-M1</version>
+                  <version>6.1.0</version>
+                </versions>
+              </versioning>
+            </metadata>`;
+
+        test('selects the newest stable version in the requested line', () => {
+            assert.strictEqual(parseLatestStableVersion(COEXISTING_LINES_XML, '1'), '1.14.4');
+            assert.strictEqual(parseLatestStableVersion(COEXISTING_LINES_XML, '6'), '6.1.0');
+        });
+
+        test('ignores <release> when it points outside the requested line', () => {
+            // <release> = 6.1.0 but caller asked for the 1.x line — we must not
+            // short-circuit to <release>; we have to walk <versions>.
+            assert.strictEqual(parseLatestStableVersion(COEXISTING_LINES_XML, '1'), '1.14.4');
+        });
+
+        test('skips pre-releases inside the requested line', () => {
+            const xml: string = `
+                <metadata>
+                  <versioning>
+                    <versions>
+                      <version>1.14.3</version>
+                      <version>1.14.4</version>
+                      <version>1.15.0-M1</version>
+                      <version>1.15.0-RC1</version>
+                    </versions>
+                  </versioning>
+                </metadata>`;
+            assert.strictEqual(parseLatestStableVersion(xml, '1'), '1.14.4');
+        });
+
+        test('returns undefined when the requested line has no stable version', () => {
+            assert.strictEqual(parseLatestStableVersion(COEXISTING_LINES_XML, '2'), undefined);
+            assert.strictEqual(parseLatestStableVersion(COEXISTING_LINES_XML, '5'), undefined);
+        });
+
+        test('matches the line only on the leading segment, not on prefix', () => {
+            // versionLine '1' must not accidentally match '10.x' or '11.x'.
+            const xml: string = `
+                <metadata>
+                  <versioning>
+                    <versions>
+                      <version>1.14.4</version>
+                      <version>10.0.0</version>
+                      <version>11.2.3</version>
+                    </versions>
+                  </versioning>
+                </metadata>`;
+            assert.strictEqual(parseLatestStableVersion(xml, '1'), '1.14.4');
+            assert.strictEqual(parseLatestStableVersion(xml, '10'), '10.0.0');
+            assert.strictEqual(parseLatestStableVersion(xml, '11'), '11.2.3');
+        });
+    });
 });

--- a/test/unmanaged-folder-suite/enableTests.test.ts
+++ b/test/unmanaged-folder-suite/enableTests.test.ts
@@ -26,24 +26,25 @@ suite('Test Enable Tests', () => {
 
     test('test enable tests for unmanaged folder', async () => {
         await enableTests(TestKind.JUnit5);
-        // A correctly downloaded artifact must be a stable release of
-        // junit-platform-console-standalone (no pre-release qualifier such as
-        // -M3, -RC1, -beta-1, ...). This guards against the stale Maven
-        // search.maven.org Solr index that used to return milestone versions
-        // as the "latest" — see microsoft/vscode-java-test#1866.
-        const STABLE_JAR_PATTERN: RegExp = /^junit-platform-console-standalone-\d+(\.\d+)*\.jar$/;
+        // TestKind.JUnit5 is now pinned to the JUnit Platform 1.x line.
+        // A correctly downloaded artifact must be a stable 1.x release of
+        // junit-platform-console-standalone (no pre-release qualifier such
+        // as -M3, -RC1, -beta-1, ...). This guards against both the stale
+        // search.maven.org Solr index (#1866) and an accidental drift back
+        // to the 6.x line.
+        const STABLE_JUNIT5_JAR_PATTERN: RegExp = /^junit-platform-console-standalone-1\.\d+(\.\d+)*\.jar$/;
         for (let i = 0; i < 5; i++) {
             if (await fse.pathExists(LIB_PATH)) {
                 const files: string[] = await fse.readdir(LIB_PATH);
-                const stableJar: string | undefined = files.find((file) => STABLE_JAR_PATTERN.test(file));
+                const stableJar: string | undefined = files.find((file) => STABLE_JUNIT5_JAR_PATTERN.test(file));
                 if (stableJar) {
                     return;
                 }
                 const anyMatching: string[] = files.filter((file) => file.includes('junit-platform-console-standalone'));
                 if (anyMatching.length > 0) {
                     assert.fail(
-                        `Downloaded jar is not a stable release. Got: ${anyMatching.join(', ')}. ` +
-                        `Expected a file matching ${STABLE_JAR_PATTERN}.`,
+                        `Downloaded jar is not a stable JUnit 5 (1.x) release. Got: ${anyMatching.join(', ')}. ` +
+                        `Expected a file matching ${STABLE_JUNIT5_JAR_PATTERN}.`,
                     );
                 }
             }

--- a/test/unmanaged-folder-suite/enableTests.test.ts
+++ b/test/unmanaged-folder-suite/enableTests.test.ts
@@ -26,14 +26,25 @@ suite('Test Enable Tests', () => {
 
     test('test enable tests for unmanaged folder', async () => {
         await enableTests(TestKind.JUnit5);
+        // A correctly downloaded artifact must be a stable release of
+        // junit-platform-console-standalone (no pre-release qualifier such as
+        // -M3, -RC1, -beta-1, ...). This guards against the stale Maven
+        // search.maven.org Solr index that used to return milestone versions
+        // as the "latest" — see microsoft/vscode-java-test#1866.
+        const STABLE_JAR_PATTERN: RegExp = /^junit-platform-console-standalone-\d+(\.\d+)*\.jar$/;
         for (let i = 0; i < 5; i++) {
             if (await fse.pathExists(LIB_PATH)) {
                 const files: string[] = await fse.readdir(LIB_PATH);
-                const downloaded: boolean = files.some((file) => {
-                    return file.includes('junit-platform-console-standalone');
-                });
-                if (downloaded) {
+                const stableJar: string | undefined = files.find((file) => STABLE_JAR_PATTERN.test(file));
+                if (stableJar) {
                     return;
+                }
+                const anyMatching: string[] = files.filter((file) => file.includes('junit-platform-console-standalone'));
+                if (anyMatching.length > 0) {
+                    assert.fail(
+                        `Downloaded jar is not a stable release. Got: ${anyMatching.join(', ')}. ` +
+                        `Expected a file matching ${STABLE_JAR_PATTERN}.`,
+                    );
                 }
             }
             await sleep(1000 /*ms*/);


### PR DESCRIPTION
## Problem

`search.maven.org`'s Solr index was frozen as part of Sonatype's migration
to the new Central Portal — `migration.json` returns `{"successful":[],
"failed":[]}` for every artifact we ship, so the legacy endpoint silently
stopped returning new releases.

For `junit-platform-console-standalone` that left the extension picking
the milestone build `1.13.0-M3` (last entry in the stale index) instead
of a real stable release, breaking "Enable Java Tests" on unmanaged
folders. See #1866 for the full report.

## Change

### UI - User select Test Framework
<img width="660" height="249" alt="image" src="https://github.com/user-attachments/assets/be66b146-14b1-45a8-8f80-39ab9914f2d8" />

### Switch the data source (fix)

Replace the `search.maven.org` Solr lookup with
`repo1.maven.org/.../maven-metadata.xml`, the Maven 2 metadata file that
every artifact on Maven Central is required to publish and that is always
in sync with what Central actually serves. This removes the dependence on
a deprecated, frozen index.

### Split JUnit Jupiter 5 and JUnit Jupiter 6 by version line

`junit-platform-console-standalone` now publishes two coexisting release
lines under the same GAV — `1.x` for Jupiter 5 and `6.x` for Jupiter 6 —
and `<release>` tracks the globally newest stable (currently `6.1.0`).
Without a per-line constraint, picking *JUnit Jupiter 5* would still
resolve to a 6.x jar.

The QuickPick now exposes two entries:

| Menu label        | Platform line | Default fallback |
|-------------------|---------------|------------------|
| JUnit Jupiter 5   | `1.x`         | `1.14.4`         |
| JUnit Jupiter 6   | `6.x`         | `6.1.0`          |

To support this, `IArtifactMetadata` gains an optional `versionLine`
field. When set, `getLatestVersion()` / `parseLatestStableVersion()`
skip the `<release>` shortcut and scan `<versions>` for the newest
stable version whose **leading segment** matches the requested line
(`'1'` matches `1.14.4` but not `10.x` or `11.x`).

### Add regression coverage

| Layer | File | Catches |
|---|---|---|
| Integration | `test/unmanaged-folder-suite/enableTests.test.ts` | Production code path: tightened to require a stable **1.x** `junit-platform-console-standalone-*.jar` after `enableTests(JUnit5)`, so any silent re-introduction of `-M3` / `-RC1` builds or accidental drift back to the 6.x line fails CI. |
| Unit | `test/suite/testDependenciesCommands.test.ts` | XML parser invariants: `<release>` happy path, fallback to `<versions>` when `<release>` is a pre-release (mirrors slf4j-api shape), and the new per-line cases — selecting newest stable in the requested line, ignoring an out-of-line `<release>`, skipping pre-releases inside the line, returning `undefined` when the line has nothing stable, and using leading-segment match (not prefix). |
| Health check | `scripts/checkVersionSources.js` + `.github/workflows/health-check.yml` | Future Sonatype breakage: weekly cron + PR/push runs that HEAD every artifact we ship (now probes both the 1.x and 6.x console-standalone lines independently) and opens / updates a tracking issue on scheduled failure. |

## Known follow-up: JUnit Jupiter 5 + current vscode-java

There is a separate upstream JDT-LS dispatch bug that routes **every**
`junit-platform-console-standalone` jar through the new "JUnit 6" runner,
which reflectively requires APIs only present in Platform 6+. So on a
vscode-java build that still bundles the affected JDT-LS, picking
*JUnit Jupiter 5* (1.x) will fail with `NoClassDefFoundError:
.../CancellationToken`.

The upstream fix is merged (eclipse.jdt.ui#2910 / `17f8fa5d9f`) and is
waiting on the eclipse.jdt.ls bump + the next `redhat.java` release.
Until then, affected users should pick *JUnit Jupiter 6* or roll back
to an older `redhat.java`. #4396 tracks the rollout.

## Closes
- #1866
