### PR TITLE
fix: refresh Test Explorer after first-time enable tests

### DIFF
--- a/src/commands/testExplorerCommands.ts
+++ b/src/commands/testExplorerCommands.ts
@@ -101,7 +101,10 @@ export async function refreshProject(classpathUri: Uri): Promise<void> {
         });
         await Promise.all(loadPromises);
     } else {
-        // URI doesn't match any known test project – skip to avoid unnecessary full refresh
+        // Bootstrap: first-time enable tests on an empty Test Explorer.
+        if (testController?.items.size === 0) {
+            await refreshExplorer();
+        }
         return;
     }
     await showTestItemsInCurrentFile();


### PR DESCRIPTION
## Problem

After **"Java: Enable Tests"** downloads a JUnit jar onto an unmanaged folder, the Test Explorer stays empty until the user manually clicks "Refresh tests". Reported in [redhat-developer/vscode-java#4396](https://github.com/redhat-developer/vscode-java/issues/4396).

## Root cause

Verified end-to-end via JDT-LS `.log` + LSP wire trace (`java.trace.server: verbose`):

1. jar lands in `lib/`
2. JDT-LS `UpdateClasspathJob` updates the classpath
3. `ClasspathUpdateHandler` sends `language/eventNotification { eventType: 100, data: <ws-uri> }`
4. vscode-java fires `onDidClasspathUpdate(uri)` → vscode-java-test calls `refreshProject(uri)`
5. **Bug**: at this moment `testController.items.size === 0` (Test Explorer hadn't resolved any project yet because there was no test framework on the classpath). The URI-matching loop iterates zero times and `refreshProject` silently returns.

## Fix

In the no-match `else` branch, fall back to a full `refreshExplorer()` when `testController.items.size === 0`. Existing skip behaviour for unrelated classpath churn (e.g. Gradle's `buildSrc`) is unchanged.

## Related

Companion to #1868 (JUnit version source) and #1869 (jar version sync) — together they unblock [vscode-java#4396](https://github.com/redhat-developer/vscode-java/issues/4396).
