### PR TITLE
feat: expose JUnit Jupiter 6 as a separate Enable Tests option

### DIFF
--- a/src/commands/testDependenciesCommands.ts
+++ b/src/commands/testDependenciesCommands.ts
@@ -98,7 +98,11 @@ async function setupUnmanagedFolder(projectUri: Uri, testKind?: TestKind): Promi
 
 async function getTestKind(): Promise<TestKind | undefined> {
     const framework: any = await window.showQuickPick([{
-        label: 'JUnit Jupiter',
+        label: 'JUnit Jupiter 6',
+        description: 'Recommended',
+        value: TestKind.JUnit6,
+    }, {
+        label: 'JUnit Jupiter 5',
         value: TestKind.JUnit5,
     }, {
         label: 'JUnit',


### PR DESCRIPTION
## Summary


Add a "JUnit Jupiter 6" entry to the **Java: Enable Tests** framework picker and rename the existing entry to "JUnit Jupiter 5".

```
JUnit Jupiter 6   ← new
JUnit Jupiter 5   ← renamed from "JUnit Jupiter"
JUnit
TestNG
```

https://github.com/user-attachments/assets/34e7a7ee-a729-4265-a0c5-63e4075fb1af



`TestKind.JUnit6` already exists in the API and `getJarIds()` already routes JUnit5 to the JUnit Platform 1.x line and JUnit6 to the 6.x line (#1868). This PR is just the UI side of that split so users can actually pick JUnit 6 from the QuickPick instead of being silently mapped to JUnit5.

## Why JUnit Jupiter 6 first

JUnit Jupiter 6 is the current upstream default — it's listed first to nudge new projects toward the supported line. JUnit Jupiter 5 stays available for projects that still target JDK 8–16 or depend on 5.x-only APIs.

## Related

Closes the UX gap left by #1868 / #1869 / #1870 for [redhat-developer/vscode-java#4396](https://github.com/redhat-developer/vscode-java/issues/4396).
