### PR TITLE
fix: ship org.objectweb.asm bundles to satisfy Jacoco 0.8.14 (#1866)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
             "./server/org.eclipse.jdt.junit5.runtime_1.2.0.v20251113-1434.jar",
             "./server/org.eclipse.jdt.junit6.runtime_1.0.0.v20251112-1701.jar",
             "./server/org.jacoco.core_0.8.14.202510111229.jar",
+            "./server/org.objectweb.asm.commons_9.9.1.jar",
+            "./server/org.objectweb.asm.tree_9.9.1.jar",
+            "./server/org.objectweb.asm_9.9.1.jar",
             "./server/org.opentest4j_1.3.0.jar"
         ],
         "viewsWelcome": [

--- a/scripts/buildJdtlsExt.js
+++ b/scripts/buildJdtlsExt.js
@@ -30,7 +30,8 @@ const bundleList = [
     'junit-platform-suite-commons_',
     'junit-platform-suite-engine_',
     'org.apiguardian.api_',
-    'org.jacoco.core_'
+    'org.jacoco.core_',
+    'org.objectweb.asm'
 ];
 // Set MAVEN_OPTS to disable XML entity size limits for JDK XML parser
 const env = { ...process.env };

--- a/scripts/buildJdtlsExt.js
+++ b/scripts/buildJdtlsExt.js
@@ -31,7 +31,9 @@ const bundleList = [
     'junit-platform-suite-engine_',
     'org.apiguardian.api_',
     'org.jacoco.core_',
-    'org.objectweb.asm'
+    'org.objectweb.asm_',
+    'org.objectweb.asm.commons_',
+    'org.objectweb.asm.tree_'
 ];
 // Set MAVEN_OPTS to disable XML entity size limits for JDK XML parser
 const env = { ...process.env };


### PR DESCRIPTION
Fixes #1803

Fixes #1866

## Problem
Issue #1866 (CherryDT's follow-up): after upgrading both `vscode-java` and `vscode-java-test` to pre-release, the test plugin fails to load with:

```
Could not resolve module: com.microsoft.java.test.plugin
  Unresolved requirement: Require-Bundle: org.objectweb.asm; bundle-version="[9.9.0,9.10.0)"
Could not resolve module: org.jacoco.core
  Unresolved requirement: Import-Package: org.objectweb.asm; version="[9.9.0,9.10.0)"
```

No test UI appears.

## Root cause
- #1798 bumped Jacoco `0.8.12 -> 0.8.14` and the asm requirement `[9.8.0,9.9.0) -> [9.9.0,9.10.0)` in `MANIFEST.MF`.
- The Eclipse platform / JDT-LS provided by `vscode-java` only ships `org.objectweb.asm` **9.8.0**.
- `scripts/buildJdtlsExt.js` has a `bundleList` allow-list that controls which bundles get copied into `server/` and registered as `contributes.javaExtensions`. It contains `org.jacoco.core_` but **no asm**, so asm 9.9 was never shipped with the extension.
- The build/CI target platform *does* include asm 9.9 (pulled transitively via the Maven target location), so all internal tests passed and the gap stayed hidden. It only surfaces at end-user runtime against a platform that provides a different asm version.

Before #1798 the requirement `[9.8.0,9.9.0)` matched the platform's 9.8.0, so asm never needed to be shipped.

## Fix
Add the `org.objectweb.asm` prefix to `bundleList`. This ships `org.objectweb.asm`, `org.objectweb.asm.commons` and `org.objectweb.asm.tree` (9.9.1) with the extension ΓÇö the broad prefix is required because Jacoco 0.8.14 also imports `asm.commons`/`asm.tree`. The asm requirement is now satisfied independently of the platform-provided asm version.

`package.json` `javaExtensions` is regenerated by the build to include the three asm jars.

## Verification
- `node scripts/buildJdtlsExt.js` succeeds; `server/` now contains `org.objectweb.asm_9.9.1.jar`, `org.objectweb.asm.commons_9.9.1.jar`, `org.objectweb.asm.tree_9.9.1.jar`.
- `package.json` updated accordingly.

Fixes the `BundleException` reported in #1866 and redhat-developer/vscode-java#4396.
