### PR TITLE
build: bump version to 0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 0.45.1
 ## What's Changed
-* feat - Run multiple selected test methods in a single JVM in https://github.com/microsoft/vscode-java-test/pull/1862
-* feat - Expose JUnit Jupiter 6 as a separate Enable Tests option in https://github.com/microsoft/vscode-java-test/pull/1871
+* perf - Run multiple selected test methods in a single JVM in https://github.com/microsoft/vscode-java-test/pull/1862
+* perf - Expose JUnit Jupiter 6 as a separate Enable Tests option in https://github.com/microsoft/vscode-java-test/pull/1871
 * fix - Use OS auto-port allocation for the test runner socket server in https://github.com/microsoft/vscode-java-test/pull/1855
 * fix - Use maven-metadata.xml to look up latest test framework version in https://github.com/microsoft/vscode-java-test/pull/1868
 * fix - Sync javaExtensions to the actual JUnit jar versions in server/ in https://github.com/microsoft/vscode-java-test/pull/1869
 * fix - Refresh Test Explorer after first-time Enable Java Tests in https://github.com/microsoft/vscode-java-test/pull/1870
 * fix - Ship org.objectweb.asm bundles to satisfy Jacoco 0.8.14 in https://github.com/microsoft/vscode-java-test/pull/1872
-* chore - Update telemetry wrapper to 0.15.1 in https://github.com/microsoft/vscode-java-test/pull/1861
-* chore(deps) - Update vulnerable dependencies in https://github.com/microsoft/vscode-java-test/pull/1857, https://github.com/microsoft/vscode-java-test/pull/1858, https://github.com/microsoft/vscode-java-test/pull/1856, https://github.com/microsoft/vscode-java-test/pull/1863, https://github.com/microsoft/vscode-java-test/pull/1864, https://github.com/microsoft/vscode-java-test/pull/1876, https://github.com/microsoft/vscode-java-test/pull/1877
 
 ## 0.45.0
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the "vscode-java-test" extension will be documented in th
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.45.1
+## What's Changed
+* feat - Run multiple selected test methods in a single JVM in https://github.com/microsoft/vscode-java-test/pull/1862
+* feat - Expose JUnit Jupiter 6 as a separate Enable Tests option in https://github.com/microsoft/vscode-java-test/pull/1871
+* fix - Use OS auto-port allocation for the test runner socket server in https://github.com/microsoft/vscode-java-test/pull/1855
+* fix - Use maven-metadata.xml to look up latest test framework version in https://github.com/microsoft/vscode-java-test/pull/1868
+* fix - Sync javaExtensions to the actual JUnit jar versions in server/ in https://github.com/microsoft/vscode-java-test/pull/1869
+* fix - Refresh Test Explorer after first-time Enable Java Tests in https://github.com/microsoft/vscode-java-test/pull/1870
+* fix - Ship org.objectweb.asm bundles to satisfy Jacoco 0.8.14 in https://github.com/microsoft/vscode-java-test/pull/1872
+* chore - Update telemetry wrapper to 0.15.1 in https://github.com/microsoft/vscode-java-test/pull/1861
+* chore(deps) - Update vulnerable dependencies in https://github.com/microsoft/vscode-java-test/pull/1857, https://github.com/microsoft/vscode-java-test/pull/1858, https://github.com/microsoft/vscode-java-test/pull/1856, https://github.com/microsoft/vscode-java-test/pull/1863, https://github.com/microsoft/vscode-java-test/pull/1864, https://github.com/microsoft/vscode-java-test/pull/1876, https://github.com/microsoft/vscode-java-test/pull/1877
+
 ## 0.45.0
 ## What's Changed
 * feat - Support excluding source paths from coverage reporting in https://github.com/microsoft/vscode-java-test/pull/1809

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to the "vscode-java-test" extension will be documented in th
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.45.1
+## 0.46.0
 ## What's Changed
-* perf - Run multiple selected test methods in a single JVM in https://github.com/microsoft/vscode-java-test/pull/1862
-* perf - Expose JUnit Jupiter 6 as a separate Enable Tests option in https://github.com/microsoft/vscode-java-test/pull/1871
+* feat - Run multiple selected test methods in a single JVM in https://github.com/microsoft/vscode-java-test/pull/1862
+* feat - Expose JUnit Jupiter 6 as a separate Enable Tests option in https://github.com/microsoft/vscode-java-test/pull/1871
 * fix - Use OS auto-port allocation for the test runner socket server in https://github.com/microsoft/vscode-java-test/pull/1855
 * fix - Use maven-metadata.xml to look up latest test framework version in https://github.com/microsoft/vscode-java-test/pull/1868
 * fix - Sync javaExtensions to the actual JUnit jar versions in server/ in https://github.com/microsoft/vscode-java-test/pull/1869

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-java-test",
-    "version": "0.45.1",
+    "version": "0.46.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-java-test",
-            "version": "0.45.1",
+            "version": "0.46.0",
             "dependencies": {
                 "fs-extra": "^10.1.0",
                 "iconv-lite": "^0.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-java-test",
-    "version": "0.45.0",
+    "version": "0.45.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-java-test",
-            "version": "0.45.0",
+            "version": "0.45.1",
             "dependencies": {
                 "fs-extra": "^10.1.0",
                 "iconv-lite": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "repository": {
         "url": "https://github.com/Microsoft/vscode-java-test"
     },
-    "version": "0.45.1",
+    "version": "0.46.0",
     "publisher": "vscjava",
     "bugs": {
         "url": "https://github.com/Microsoft/vscode-java-test/issues"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "repository": {
         "url": "https://github.com/Microsoft/vscode-java-test"
     },
-    "version": "0.45.0",
+    "version": "0.45.1",
     "publisher": "vscjava",
     "bugs": {
         "url": "https://github.com/Microsoft/vscode-java-test/issues"


### PR DESCRIPTION
## Summary
- Bump extension version from 0.45.0 to 0.46.0.
- Add the 0.46.0 changelog entries for user-facing changes since 0.45.0.
- Omit CI/workflow-only and internal dependency/telemetry-only changes from the changelog.

## Validation
- npm run compile