### PR TITLE
Analyze delegated coverage once per test run

### DIFF
--- a/java-extension/com.microsoft.java.test.plugin.test/src/com/microsoft/java/test/plugin/coverage/CoverageHandlerTest.java
+++ b/java-extension/com.microsoft.java.test.plugin.test/src/com/microsoft/java/test/plugin/coverage/CoverageHandlerTest.java
@@ -21,9 +21,13 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.junit.Test;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CoverageHandlerTest extends AbstractProjectsManagerBasedTest {
@@ -44,6 +48,33 @@ public class CoverageHandlerTest extends AbstractProjectsManagerBasedTest {
                 assertTrue(methodCoverage.getLineNumber() > 0);
             }
         }
+    }
+
+    @Test
+    public void testGetCoverageDetailFindsNestedExecFiles() throws Exception {
+        importProjects(Collections.singleton("coverage-test"));
+        final IJavaProject javaProject = ProjectUtils.getJavaProject("coverage-test");
+        final File projectDir = javaProject.getProject().getLocation().toFile();
+
+        // Baseline: execution data discovered directly under the base path.
+        final List<SourceFileCoverage> rootCoverage =
+                new CoverageHandler(javaProject, projectDir.getAbsolutePath())
+                        .getCoverageDetail(new NullProgressMonitor());
+
+        // The same execution data placed only in a nested sub-directory must be
+        // discovered recursively (a delegated run writes `.exec` files per
+        // project/task sub-directory) and yield the same coverage.
+        final File nestedBase = new File(projectDir, "nested-exec");
+        final File nestedDir = new File(nestedBase, "sub");
+        nestedDir.mkdirs();
+        Files.copy(new File(projectDir, "jacoco.exec").toPath(),
+                new File(nestedDir, "jacocoNested.exec").toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+        final List<SourceFileCoverage> nestedCoverage =
+                new CoverageHandler(javaProject, nestedBase.getAbsolutePath())
+                        .getCoverageDetail(new NullProgressMonitor());
+
+        assertEquals(rootCoverage.size(), nestedCoverage.size());
     }
 
 }

--- a/java-extension/com.microsoft.java.test.plugin.test/src/com/microsoft/java/test/plugin/coverage/CoverageHandlerTest.java
+++ b/java-extension/com.microsoft.java.test.plugin.test/src/com/microsoft/java/test/plugin/coverage/CoverageHandlerTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class CoverageHandlerTest extends AbstractProjectsManagerBasedTest {
 
@@ -75,6 +76,25 @@ public class CoverageHandlerTest extends AbstractProjectsManagerBasedTest {
                         .getCoverageDetail(new NullProgressMonitor());
 
         assertEquals(rootCoverage.size(), nestedCoverage.size());
+    }
+
+    @Test
+    public void testGetCoverageDetailFailsWithoutExecutionData() throws Exception {
+        importProjects(Collections.singleton("coverage-test"));
+        final IJavaProject javaProject = ProjectUtils.getJavaProject("coverage-test");
+        final File emptyDir = new File(javaProject.getProject().getLocation().toFile(), "no-exec");
+        emptyDir.mkdirs();
+
+        // Analyzing no execution data reports every line as uncovered, which is
+        // indistinguishable from a run that genuinely covered nothing. A run whose
+        // agent never attached has to be reported as an error instead of as 0%.
+        try {
+            new CoverageHandler(javaProject, emptyDir.getAbsolutePath())
+                    .getCoverageDetail(new NullProgressMonitor());
+            fail("Expected the absence of execution data to be reported as an error.");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains(emptyDir.getAbsolutePath()));
+        }
     }
 
 }

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/coverage/CoverageHandler.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/coverage/CoverageHandler.java
@@ -42,6 +42,7 @@ import org.jacoco.core.tools.ExecFileLoader;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -52,16 +53,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CoverageHandler {
 
     private IJavaProject javaProject;
     private Path reportBasePath;
-
-    /**
-     * The Jacoco data file name
-     */
-    private static final String JACOCO_EXEC = "jacoco.exec";
 
     public CoverageHandler(IJavaProject javaProject, String basePath) {
         this.javaProject = javaProject;
@@ -77,9 +75,14 @@ public class CoverageHandler {
         javaProjects.addAll(getAllJavaProjects(javaProject));
         final Map<IPath, List<IPath>> outputToSourcePaths = getOutputToSourcePathsMapping(javaProjects);
 
-        final File executionDataFile = reportBasePath.resolve(JACOCO_EXEC).toFile();
+        final List<File> executionDataFiles = findExecutionDataFiles(reportBasePath);
+        if (executionDataFiles.isEmpty()) {
+            return Collections.emptyList();
+        }
         final ExecFileLoader execFileLoader = new ExecFileLoader();
-        execFileLoader.load(executionDataFile);
+        for (final File executionDataFile : executionDataFiles) {
+            execFileLoader.load(executionDataFile);
+        }
         for (final Map.Entry<IPath, List<IPath>> entry : outputToSourcePaths.entrySet()) {
             final CoverageBuilder coverageBuilder = new CoverageBuilder();
             final Analyzer analyzer = new Analyzer(
@@ -116,6 +119,24 @@ public class CoverageHandler {
             }
         }
         return coverage;
+    }
+
+    /**
+     * Recursively collect all JaCoCo execution data (<code>*.exec</code>) files under the
+     * given base path. A single delegated coverage run can produce multiple execution data
+     * files (for example one per Gradle project or per test task), all of which are merged.
+     */
+    private static List<File> findExecutionDataFiles(Path basePath) throws IOException {
+        if (!basePath.toFile().exists()) {
+            return Collections.emptyList();
+        }
+        try (Stream<Path> stream = Files.walk(basePath)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".exec"))
+                    .map(Path::toFile)
+                    .collect(Collectors.toList());
+        }
     }
 
     private Map<IPath, List<IPath>> getOutputToSourcePathsMapping(List<IJavaProject> javaProjects)

--- a/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/coverage/CoverageHandler.java
+++ b/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/coverage/CoverageHandler.java
@@ -77,7 +77,12 @@ public class CoverageHandler {
 
         final List<File> executionDataFiles = findExecutionDataFiles(reportBasePath);
         if (executionDataFiles.isEmpty()) {
-            return Collections.emptyList();
+            // Analyzing nothing yields a report where every line is uncovered, which is
+            // indistinguishable from tests that genuinely covered nothing. Fail loudly
+            // instead, so a run that never attached the agent cannot be read as 0%.
+            throw new IllegalStateException("No JaCoCo execution data (*.exec) was found under " +
+                    reportBasePath + ". The tests may not have started, or the test runner may " +
+                    "not have attached the coverage agent.");
         }
         final ExecFileLoader execFileLoader = new ExecFileLoader();
         for (final File executionDataFile : executionDataFiles) {

--- a/src/controller/testController.ts
+++ b/src/controller/testController.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as _ from 'lodash';
+import * as fse from 'fs-extra';
 import * as path from 'path';
 import { CancellationToken, DebugConfiguration, Disposable, FileCoverage, FileCoverageDetail, FileSystemWatcher, Location, MarkdownString, RelativePattern, TestController, TestItem, TestMessage, TestRun, TestRunProfileKind, TestRunRequest, tests, TestTag, Uri, window, workspace, WorkspaceFolder } from 'vscode';
 import { instrumentOperation, sendError, sendInfo } from 'vscode-extension-telemetry-wrapper';
@@ -19,6 +20,7 @@ import { resolveLaunchConfigurationForRunner } from '../utils/launchUtils';
 import { dataCache, ITestItemData } from './testItemDataCache';
 import { createTestItem, findDirectTestChildrenForClass, findTestPackagesAndTypes, findTestTypesAndMethods, loadJavaProjects, resolvePath, synchronizeItemsRecursively, updateItemForDocumentWithDebounce } from './utils';
 import { JavaTestCoverageProvider } from '../provider/JavaTestCoverageProvider';
+import { getDelegatedJacocoReportBasePath, getJacocoReportBasePath } from '../utils/coverageUtils';
 import { testRunnerService } from './testRunnerService';
 import { IRunTestContext, TestRunner, TestFinishEvent, TestItemStatusChangeEvent, TestKind, TestLevel, TestResultState, TestIdParts } from '../java-test-runner.api';
 import { processStackTraceLine } from '../runners/utils';
@@ -212,6 +214,8 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
                         window.showErrorMessage(`Failed to get workspace folder from test item: ${itemsPerProject[0].label}.`);
                         continue;
                     }
+                    const isCoverageRun: boolean = request.profile?.kind === TestRunProfileKind.Coverage;
+                    const testRunner: TestRunner | undefined = testRunnerService.getRunner(request.profile?.label, request.profile?.kind);
                     const testContext: IRunTestContext = {
                         isDebug: option.isDebug,
                         kind: TestKind.None,
@@ -221,11 +225,30 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
                         workspaceFolder,
                         profile: request.profile,
                         testConfig: await loadRunConfig(itemsPerProject, workspaceFolder),
+                        // A delegated runner writes its execution data to a directory of its
+                        // own so that the two runners never merge each other's `.exec` files.
+                        coverage: isCoverageRun ? {
+                            outputDirectory: testRunner ?
+                                getDelegatedJacocoReportBasePath(projectName) :
+                                getJacocoReportBasePath(projectName),
+                        } : undefined,
                     };
+                    if (isCoverageRun && testContext.coverage &&
+                            testContext.testConfig?.coverage?.appendResult === false) {
+                        // JaCoCo appends to existing execution data by default. An explicit
+                        // `appendResult: false` means this run must not see any earlier data,
+                        // so drop what a previous run left behind.
+                        await fse.remove(testContext.coverage.outputDirectory);
+                    }
                     if (testRunner) {
                         await executeWithTestRunner(option, testRunner, testContext, run, disposables);
                         disposables.forEach((d: Disposable) => d.dispose());
                         disposables = [];
+                        if (isCoverageRun) {
+                            // The delegate path returns before reaching the shared
+                            // coverage collection below, so analyze the `.exec` files here.
+                            await coverageProvider!.provideFileCoverage(testContext);
+                        }
                         continue;
                     }
                     const testKindMapping: Map<TestKind, TestItem[]> = mapTestItemsByKind(itemsPerProject);

--- a/src/controller/testController.ts
+++ b/src/controller/testController.ts
@@ -20,9 +20,9 @@ import { resolveLaunchConfigurationForRunner } from '../utils/launchUtils';
 import { dataCache, ITestItemData } from './testItemDataCache';
 import { createTestItem, findDirectTestChildrenForClass, findTestPackagesAndTypes, findTestTypesAndMethods, loadJavaProjects, resolvePath, synchronizeItemsRecursively, updateItemForDocumentWithDebounce } from './utils';
 import { JavaTestCoverageProvider } from '../provider/JavaTestCoverageProvider';
-import { getDelegatedJacocoReportBasePath, getJacocoReportBasePath } from '../utils/coverageUtils';
+import { createDelegatedExecutionDataDirectory, getJacocoAgentJarUri, getJacocoReportBasePath } from '../utils/coverageUtils';
 import { testRunnerService } from './testRunnerService';
-import { IRunTestContext, TestRunner, TestFinishEvent, TestItemStatusChangeEvent, TestKind, TestLevel, TestResultState, TestIdParts } from '../java-test-runner.api';
+import { CoverageRequest, IRunTestContext, TestRunner, TestFinishEvent, TestItemStatusChangeEvent, TestKind, TestLevel, TestResultState, TestIdParts } from '../java-test-runner.api';
 import { processStackTraceLine } from '../runners/utils';
 import { parsePartsFromTestId } from '../utils/testItemUtils';
 
@@ -177,12 +177,13 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
     }
 
     const run: TestRun = testController!.createTestRun(request);
+    const isCoverageRun: boolean = request.profile?.kind === TestRunProfileKind.Coverage;
     let coverageProvider: JavaTestCoverageProvider | undefined;
-    if (request.profile?.kind === TestRunProfileKind.Coverage) {
+    if (isCoverageRun) {
         coverageProvider = new JavaTestCoverageProvider();
         // QUESTION: Fix this?
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        request.profile.loadDetailedCoverage = (_testRun: TestRun, fileCoverage: FileCoverage, _token: CancellationToken): Promise<FileCoverageDetail[]> => {
+        request.profile!.loadDetailedCoverage = (_testRun: TestRun, fileCoverage: FileCoverage, _token: CancellationToken): Promise<FileCoverageDetail[]> => {
             return Promise.resolve(coverageProvider!.getCoverageDetails(fileCoverage.uri));
         };
     }
@@ -203,6 +204,19 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
             });
             // TODO: first group by project, then merge test methods.
             const queue: TestItem[][] = mergeTestMethods(testItems);
+            // A delegated runner is handed one directory for the whole run, not one per
+            // batch or per project, so that a run which fans out over several projects,
+            // tasks or retries still produces a single set of data to analyze.
+            const coverageRequest: CoverageRequest | undefined = isCoverageRun && testRunner ? {
+                format: 'jacoco-exec',
+                version: 1,
+                executionDataDirectory: await createDelegatedExecutionDataDirectory(),
+                agentJar: getJacocoAgentJarUri(),
+            } : undefined;
+            // Analysis happens once, after every batch has run, so that the last batch
+            // cannot publish a report that hides what the batches before it covered.
+            const coverageContexts: Map<string, IRunTestContext> = new Map<string, IRunTestContext>();
+            const clearedCoverageProjects: Set<string> = new Set<string>();
             for (const testsInQueue of queue) {
                 if (testsInQueue.length === 0) {
                     continue;
@@ -214,41 +228,34 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
                         window.showErrorMessage(`Failed to get workspace folder from test item: ${itemsPerProject[0].label}.`);
                         continue;
                     }
-                    const isCoverageRun: boolean = request.profile?.kind === TestRunProfileKind.Coverage;
-                    const testRunner: TestRunner | undefined = testRunnerService.getRunner(request.profile?.label, request.profile?.kind);
                     const testContext: IRunTestContext = {
                         isDebug: option.isDebug,
                         kind: TestKind.None,
                         projectName,
                         testItems: itemsPerProject,
                         testRun: run,
+                        cancellationToken: token,
                         workspaceFolder,
                         profile: request.profile,
                         testConfig: await loadRunConfig(itemsPerProject, workspaceFolder),
-                        // A delegated runner writes its execution data to a directory of its
-                        // own so that the two runners never merge each other's `.exec` files.
-                        coverage: isCoverageRun ? {
-                            outputDirectory: testRunner ?
-                                getDelegatedJacocoReportBasePath(projectName) :
-                                getJacocoReportBasePath(projectName),
-                        } : undefined,
+                        coverage: coverageRequest,
                     };
-                    if (isCoverageRun && testContext.coverage &&
-                            testContext.testConfig?.coverage?.appendResult === false) {
-                        // JaCoCo appends to existing execution data by default. An explicit
-                        // `appendResult: false` means this run must not see any earlier data,
-                        // so drop what a previous run left behind.
-                        await fse.remove(testContext.coverage.outputDirectory);
+                    if (isCoverageRun) {
+                        coverageContexts.set(projectName, testContext);
+                        if (!coverageRequest && testContext.testConfig?.coverage?.appendResult === false
+                                && !clearedCoverageProjects.has(projectName)) {
+                            // The built-in runner appends to one file per project, so an
+                            // explicit `appendResult: false` has to drop what earlier runs
+                            // left behind. Only once per project: clearing it again between
+                            // batches would throw away this very run's data.
+                            clearedCoverageProjects.add(projectName);
+                            await fse.remove(getJacocoReportBasePath(projectName));
+                        }
                     }
                     if (testRunner) {
                         await executeWithTestRunner(option, testRunner, testContext, run, disposables);
                         disposables.forEach((d: Disposable) => d.dispose());
                         disposables = [];
-                        if (isCoverageRun) {
-                            // The delegate path returns before reaching the shared
-                            // coverage collection below, so analyze the `.exec` files here.
-                            await coverageProvider!.provideFileCoverage(testContext);
-                        }
                         continue;
                     }
                     const testKindMapping: Map<TestKind, TestItem[]> = mapTestItemsByKind(itemsPerProject);
@@ -318,10 +325,13 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
                             await runner.tearDown();
                         }
                     }
-                    if (request.profile?.kind === TestRunProfileKind.Coverage) {
-                        await coverageProvider!.provideFileCoverage(testContext);
-                    }
                 }
+            }
+            if (isCoverageRun && !token.isCancellationRequested) {
+                for (const coverageContext of coverageContexts.values()) {
+                    await coverageProvider!.provideFileCoverage(coverageContext);
+                }
+                await discardExecutionData(coverageRequest, coverageContexts);
             }
             return resolve();
         });
@@ -329,6 +339,27 @@ export const runTests: (request: TestRunRequest, option: IRunOption) => any = in
         run.end();
     }
 });
+
+/**
+ * Removes a delegated run's execution data when it must not outlive the run.
+ *
+ * With the default `appendResult` the directory is deliberately kept, because
+ * the next run analyzes the whole root and merges it. An explicit
+ * `appendResult: false` means the opposite, so the data goes as soon as it has
+ * been analyzed. Discarding afterwards rather than clearing beforehand is what
+ * keeps a run from deleting data a concurrent run is still writing.
+ */
+async function discardExecutionData(coverage: CoverageRequest | undefined,
+    contexts: Map<string, IRunTestContext>): Promise<void> {
+    if (!coverage) {
+        return;
+    }
+    const isDiscarded: boolean = [...contexts.values()].some((context: IRunTestContext) =>
+        context.testConfig?.coverage?.appendResult === false);
+    if (isDiscarded) {
+        await fse.remove(coverage.executionDataDirectory.fsPath);
+    }
+}
 
 async function executeWithTestRunner(option: IRunOption, testRunner: TestRunner, testContext: IRunTestContext, run: TestRun, disposables: Disposable[]) {
     option.progressReporter?.done();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import { testSourceProvider } from './provider/testSourceProvider';
 import { registerAskForChoiceCommand, registerAdvanceAskForChoice, registerAskForInputCommand } from './commands/askForOptionCommands';
 import { enableTests } from './commands/testDependenciesCommands';
 import { testRunnerService } from './controller/testRunnerService';
-import { TestRunner } from './java-test-runner.api';
+import { JACOCO_EXEC_COVERAGE_CAPABILITY, TestRunner } from './java-test-runner.api';
 import { parsePartsFromTestId, parseTestIdFromParts } from './utils/testItemUtils';
 
 export let extensionContext: ExtensionContext;
@@ -39,6 +39,7 @@ export async function activate(context: ExtensionContext): Promise<any> {
         },
         parseTestIdFromParts,
         parsePartsFromTestId,
+        capabilities: Object.freeze([JACOCO_EXEC_COVERAGE_CAPABILITY]),
     };
 }
 

--- a/src/java-test-runner.api.ts
+++ b/src/java-test-runner.api.ts
@@ -21,6 +21,87 @@ export type parseTestIdFromParts = (parts: TestIdParts) => string;
  */
 export type parsePartsFromTestId = (id: string) => TestIdParts;
 
+/**
+ * @todo Proposed API
+ * The optional features this extension supports, so that consumers can
+ * feature-detect before relying on them. Versions released before capability
+ * declaration expose no `capabilities` member at all, so consumers must treat
+ * an absent member as "no optional capability supported".
+ */
+export type capabilities = readonly string[];
+
+/**
+ * @todo Proposed API
+ * Capability name: this extension populates {@link IRunTestContext.coverage}
+ * with a version 1 `jacoco-exec` {@link CoverageRequest} and analyzes the
+ * execution data a delegated runner produces for it.
+ *
+ * The trailing `@1` pins {@link CoverageRequest.version}. An incompatible
+ * revision of the contract is advertised under a new capability name, so a
+ * delegated runner never has to guess which shape it is handed.
+ *
+ * A delegated runner must not register a Coverage test profile unless the
+ * host advertises this capability, otherwise the profile can only fail.
+ */
+export const JACOCO_EXEC_COVERAGE_CAPABILITY: string = 'jacoco-exec@1';
+
+/**
+ * @todo Proposed API
+ * Asks a delegated runner to produce JaCoCo execution data for a test run.
+ *
+ * This is deliberately a minimal, versioned artifact request: it says which
+ * artifact to produce, where to put it, and which tool to produce it with, and
+ * nothing else. Report formats, source lookup, analysis scope and the user's
+ * coverage settings stay on the side that performs the analysis.
+ *
+ * Contract:
+ * - The host creates {@link executionDataDirectory} before the run and owns its
+ *   lifetime. A runner must never create, clear or delete it; doing so races
+ *   with other runs.
+ * - The directory belongs to a single test run and is shared by every project
+ *   and every batch within it. A runner may write as many `.exec` files as it
+ *   likes anywhere below it, and owns making their paths unique. The host
+ *   merges the whole tree recursively.
+ * - A runner must attach the agent at {@link agentJar} rather than one of its
+ *   own. Only that jar is guaranteed to match the analyzer the host will use.
+ * - A runner must not pass `append=false` to the agent. A single project and
+ *   task can be launched more than once within one test run, and each launch
+ *   has to add to the previous one instead of replacing it.
+ * - The host analyzes once, after the whole run finishes. A runner never has to
+ *   merge, convert or report anything.
+ *
+ * Cancellation is not part of this request; it stays on
+ * {@link IRunTestContext.cancellationToken}.
+ */
+export interface CoverageRequest {
+    /**
+     * The artifact to produce. Only JaCoCo execution data is defined today; the
+     * field exists so a different artifact can be requested later without
+     * reshaping {@link IRunTestContext}.
+     */
+    format: 'jacoco-exec';
+
+    /**
+     * The revision of this contract, matching the `@1` in
+     * {@link JACOCO_EXEC_COVERAGE_CAPABILITY}. A runner that does not recognize
+     * the value must refuse the run instead of guessing.
+     */
+    version: 1;
+
+    /**
+     * Directory that receives this run's `.exec` files. Unique per test run and
+     * shared by every project and batch in that run.
+     */
+    executionDataDirectory: vscode.Uri;
+
+    /**
+     * The JaCoCo agent to attach, for example as
+     * `-javaagent:<agentJar>=destfile=<file>`. Supplied by the host so the agent
+     * and the analyzer are always the same JaCoCo version.
+     */
+    agentJar: vscode.Uri;
+}
+
 
 /**
  * @todo Proposed API
@@ -210,6 +291,22 @@ export interface IRunTestContext {
      * The configuration for this test run.
      */
     testConfig?: IExecutionConfig;
+
+    /**
+     * Cancelled when the user cancels the test run. Absent on hosts released
+     * before this member existed, where {@link testRun}'s own token is the
+     * closest equivalent.
+     *
+     * A runner must observe this and must still report the run as finished
+     * afterwards, so a cancelled run releases whatever the runner serializes on.
+     */
+    cancellationToken?: vscode.CancellationToken;
+
+    /**
+     * Set only for Coverage-kind runs, and only when the host is delegating the
+     * production of execution data to the runner. See {@link CoverageRequest}.
+     */
+    coverage?: CoverageRequest;
 }
 
 /**

--- a/src/provider/JavaTestCoverageProvider.ts
+++ b/src/provider/JavaTestCoverageProvider.ts
@@ -11,9 +11,9 @@ export class JavaTestCoverageProvider {
 
     private coverageDetails: Map<Uri, FileCoverageDetail[]> = new Map<Uri, FileCoverageDetail[]>();
 
-    public async provideFileCoverage({testRun: run, projectName, testConfig}: IRunTestContext): Promise<void> {
+    public async provideFileCoverage({testRun: run, projectName, testConfig, coverage}: IRunTestContext): Promise<void> {
         const sourceFileCoverages: ISourceFileCoverage[] = await executeJavaLanguageServerCommand<void>(JavaTestRunnerDelegateCommands.GET_COVERAGE_DETAIL,
-            projectName, getJacocoReportBasePath(projectName)) || [];
+            projectName, coverage?.outputDirectory ?? getJacocoReportBasePath(projectName)) || [];
         const sourceFileCoverageExclusions: minimatch.Minimatch[] = (testConfig?.coverage?.excludes ?? []).map((exclusion: string) =>
             new minimatch.Minimatch(exclusion, {flipNegate: true, nonegate: true}));
         const sourceFileCoveragesToReport: ISourceFileCoverage[] = [];

--- a/src/provider/JavaTestCoverageProvider.ts
+++ b/src/provider/JavaTestCoverageProvider.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 import * as minimatch from 'minimatch';
-import { BranchCoverage, DeclarationCoverage, FileCoverage, FileCoverageDetail, Position, StatementCoverage, Uri } from 'vscode';
-import { getJacocoReportBasePath } from '../utils/coverageUtils';
+import { BranchCoverage, DeclarationCoverage, FileCoverage, FileCoverageDetail, Position, StatementCoverage, Uri, window } from 'vscode';
+import { getDelegatedExecutionDataRoot, getJacocoReportBasePath } from '../utils/coverageUtils';
 import { executeJavaLanguageServerCommand } from '../utils/commandUtils';
 import { JavaTestRunnerDelegateCommands } from '../constants';
 import { IRunTestContext } from '../java-test-runner.api';
@@ -11,9 +11,18 @@ export class JavaTestCoverageProvider {
 
     private coverageDetails: Map<Uri, FileCoverageDetail[]> = new Map<Uri, FileCoverageDetail[]>();
 
-    public async provideFileCoverage({testRun: run, projectName, testConfig, coverage}: IRunTestContext): Promise<void> {
-        const sourceFileCoverages: ISourceFileCoverage[] = await executeJavaLanguageServerCommand<void>(JavaTestRunnerDelegateCommands.GET_COVERAGE_DETAIL,
-            projectName, coverage?.outputDirectory ?? getJacocoReportBasePath(projectName)) || [];
+    public async provideFileCoverage(context: IRunTestContext): Promise<void> {
+        const {testRun: run, projectName, testConfig} = context;
+        let sourceFileCoverages: ISourceFileCoverage[];
+        try {
+            sourceFileCoverages = await executeJavaLanguageServerCommand<void>(JavaTestRunnerDelegateCommands.GET_COVERAGE_DETAIL,
+                projectName, getAnalysisPath(context)) || [];
+        } catch (error) {
+            // Reporting nothing is better than reporting a report-shaped 0%, and the run
+            // itself already succeeded, so surface the failure without failing the tests.
+            window.showErrorMessage(`Failed to analyze test coverage for '${projectName}': ${error instanceof Error ? error.message : error}`);
+            return;
+        }
         const sourceFileCoverageExclusions: minimatch.Minimatch[] = (testConfig?.coverage?.excludes ?? []).map((exclusion: string) =>
             new minimatch.Minimatch(exclusion, {flipNegate: true, nonegate: true}));
         const sourceFileCoveragesToReport: ISourceFileCoverage[] = [];
@@ -53,6 +62,25 @@ export class JavaTestCoverageProvider {
     public getCoverageDetails(uri: Uri): FileCoverageDetail[] {
         return this.coverageDetails.get(uri) || [];
     }
+}
+
+/**
+ * The directory tree to merge execution data from.
+ *
+ * The built-in runner keeps appending to one file per project, so JaCoCo's own
+ * `append` already implements `appendResult` for it. A delegated runner instead
+ * writes into a directory of its own for every run, so `appendResult` becomes a
+ * question of how wide to analyze: this run's directory only, or the root that
+ * still holds the directories of the runs before it. Expressing it as scope
+ * rather than as deleting data keeps concurrent runs from erasing each other.
+ */
+function getAnalysisPath({projectName, testConfig, coverage}: IRunTestContext): string {
+    if (!coverage) {
+        return getJacocoReportBasePath(projectName);
+    }
+    return testConfig?.coverage?.appendResult === false ?
+        coverage.executionDataDirectory.fsPath :
+        getDelegatedExecutionDataRoot();
 }
 
 interface ISourceFileCoverage {

--- a/src/utils/coverageUtils.ts
+++ b/src/utils/coverageUtils.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { DebugConfiguration } from 'vscode';
+import { DebugConfiguration, Uri } from 'vscode';
 import { extensionContext } from '../extension';
+import { randomUUID } from 'crypto';
+import * as fse from 'fs-extra';
 import * as path from 'path';
 
 const jacocoAgentRegex: RegExp = /org\.jacoco\.agent-\d+\.\d+\.\d+-runtime\.jar$/;
@@ -29,6 +31,80 @@ export function getJacocoAgentPath(debugConfiguration: DebugConfiguration): stri
 
 export function getJacocoReportBasePath(projectName: string): string {
     return path.join(extensionContext.storageUri!.fsPath, projectName, 'coverage');
+}
+
+/**
+ * The execution data directory used when a run is handed to a delegated runner.
+ *
+ * Delegated data is kept outside {@link getJacocoReportBasePath} so the built-in
+ * and the delegated runner can never merge each other's execution data, and it
+ * is kept outside the per-project directories because one delegated run can
+ * cover several projects at once.
+ */
+export function getDelegatedExecutionDataRoot(): string {
+    return path.join(extensionContext.storageUri!.fsPath, 'coverage-delegate');
+}
+
+/**
+ * An execution data directory survives its run so that a later run with the
+ * default `appendResult` can still merge it. This bounds how long that lasts;
+ * anything older than this cannot belong to a live run.
+ */
+const DELEGATED_EXECUTION_DATA_RETENTION_MS: number = 24 * 60 * 60 * 1000;
+
+/**
+ * Creates the directory that carries one test run's JaCoCo execution data.
+ *
+ * The directory is unique per test run and shared by every project and batch in
+ * it, so that a run which fans out over several projects, tasks or retries
+ * still yields a single set of data to analyze. The delegated runner only ever
+ * writes into it; creation, retention and removal stay here.
+ */
+export async function createDelegatedExecutionDataDirectory(): Promise<Uri> {
+    const root: string = getDelegatedExecutionDataRoot();
+    await pruneDelegatedExecutionData(root);
+    const directory: string = path.join(root, randomUUID());
+    await fse.ensureDir(directory);
+    return Uri.file(directory);
+}
+
+/**
+ * Drops execution data left behind by runs that are long over, so that keeping
+ * data for `appendResult` does not grow without bound. A directory younger than
+ * the retention window is never touched, because a concurrent run may still be
+ * writing into it.
+ */
+async function pruneDelegatedExecutionData(root: string): Promise<void> {
+    let entries: string[];
+    try {
+        entries = await fse.readdir(root);
+    } catch {
+        return;
+    }
+    const deadline: number = Date.now() - DELEGATED_EXECUTION_DATA_RETENTION_MS;
+    await Promise.all(entries.map(async (entry: string) => {
+        const candidate: string = path.join(root, entry);
+        try {
+            const stats: fse.Stats = await fse.stat(candidate);
+            if (stats.mtimeMs < deadline) {
+                await fse.remove(candidate);
+            }
+        } catch {
+            // Raced with another run removing the same directory; nothing to do.
+        }
+    }));
+}
+
+/**
+ * The JaCoCo agent handed to a delegated runner.
+ *
+ * This is the agent shipped with this extension, which is the only one
+ * guaranteed to match the version of the analyzer in the language server. A
+ * runner attaching an agent of its own can silently produce execution data with
+ * class ids the analyzer will not recognize.
+ */
+export function getJacocoAgentJarUri(): Uri {
+    return Uri.file(extensionContext.asAbsolutePath('server/jacocoagent.jar'));
 }
 
 export function getJacocoDataFilePath(projectName: string): string {


### PR DESCRIPTION
## Why

Coverage for a delegated test run was collected and published from inside the loop that runs each batch of tests, one batch per project and per set of classes. A run split over several batches therefore published a report per batch. Because file coverage is stored rather than merged, the last batch hid everything the batches before it had covered.

The pre-run cleanup lived in the same loop, which made it worse in two ways: an explicit `appendResult: false` threw away the data the run itself had just produced, and because the directory was fixed per project rather than per run, two runs started close together could erase each other.

Analyzing no execution data at all reported every line as uncovered — indistinguishable from a run that genuinely covered nothing. A run whose agent never attached looked like a real 0%.

## What

**One directory per run, analyzed once.** A delegated run gets a directory of its own, and every project's data is analyzed after all batches have finished rather than after each one.

**`appendResult` becomes a matter of scope, not deletion.** Analyze only this run's directory, or the root that still holds the runs before it. Nothing is deleted while a run might be writing into it, which is what let concurrent runs erase each other. Old run directories are collected on a time bound instead, and a directory younger than that bound is never touched.

**No execution data is an error.** A run that produced nothing reports the failure rather than a fabricated 0%.

## The contract

Delegated coverage now goes through an explicit request rather than a bare output path:

```ts
interface CoverageRequest {
    format: 'jacoco-exec';
    version: 1;
    executionDataDirectory: vscode.Uri;
    agentJar: vscode.Uri;
}
```

- The **agent jar comes from here**, so the agent that writes the data and the analyzer that reads it are always the same version. A runner does not choose, resolve or configure one.
- **This extension owns the directory** — it creates it, decides how widely to analyze, and cleans up. A runner writes `.exec` files into it and must not clear it or write with `append=false`.
- Nothing about *reporting* is in the payload: no XML, no source directories, no report tasks. The runner produces execution data; analysis happens here.
- Cancellation is `IRunTestContext.cancellationToken`, not part of the coverage request.

Runners advertise support with the `jacoco-exec@1` capability, so the version is negotiated rather than assumed.

## Testing

- `tsc` and `eslint` clean.
- `mvnw clean verify` builds the Java plugin clean, including checkstyle.
- New `CoverageHandlerTest` case covers the no-execution-data failure.
