### PR TITLE
build: drop the unreachable snapshot repository and pin p2 to its origin

### DIFF
--- a/java-extension/pom.xml
+++ b/java-extension/pom.xml
@@ -95,13 +95,4 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>oss.sonatype.org</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/scripts/buildJdtlsExt.js
+++ b/scripts/buildJdtlsExt.js
@@ -38,7 +38,10 @@ const bundleList = [
 // Set MAVEN_OPTS to disable XML entity size limits for JDK XML parser
 const env = { ...process.env };
 env.MAVEN_OPTS = (env.MAVEN_OPTS || '') + ' -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -DentityExpansionLimit=0';
-cp.execSync(`${mvnw()} clean verify`, { cwd: serverDir, stdio: [0, 1, 2], env });
+// `eclipse.p2.mirrors=false` stops p2 from following download.eclipse.org's mirror
+// redirect, which hands out a different third party host per request and makes the
+// set of addresses the build contacts impossible to express as an allow list.
+cp.execSync(`${mvnw()} clean verify -Declipse.p2.mirrors=false`, { cwd: serverDir, stdio: [0, 1, 2], env });
 copy(path.join(serverDir, 'com.microsoft.java.test.plugin/target'), path.resolve('server'), (file) => path.extname(file) === '.jar');
 copy(path.join(serverDir, 'com.microsoft.java.test.runner/target'), path.resolve('server'), (file) => file.endsWith('jar-with-dependencies.jar'));
 copy(path.join(serverDir, 'com.microsoft.java.test.plugin.site/target/repository/plugins'), path.resolve('server'), (file) => {


### PR DESCRIPTION
Part of the remediation for ICM [840100965](https://portal.microsofticm.com/imp/v5/incidents/details/840100965/summary) (MountainPass SR21, SFI Network Isolation / CFS adoption). The npm side of these pipelines is handled by #1893; this PR is the Maven side.

The goal of SR21 is that a build can run on a network isolated pool. That requires knowing every host the build contacts. This PR removes two obstacles to that, neither of which changes what the build produces.

## 1. `oss.sonatype.org` is unreachable by construction

`java-extension/pom.xml` declares a **snapshots** repository, but every artifact resolved against it carries a **release** version, so Maven can only ever get a 404 back. Build [31824861](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31824861):

| | count |
|---|---|
| `Downloading from oss.sonatype.org` | 196 |
| `Downloaded from oss.sonatype.org` | **0** |

Every one of those 196 requests failed and Maven fell back to Central. Removing the entry drops an external host and 196 failed round trips, and cannot change resolution because it never resolved anything.

## 2. p2 mirror redirects make the host set unknowable

`download.eclipse.org` answers p2 requests with a redirect to a mirror picked **per request** from a pool of third party hosts. `com.microsoft.java.test.tp.target` references `/eclipse/updates/4.38/` and `/releases/2025-12/`, both of which are mirrored, so that build read most of its bundles from eight hosts the repository never declares:

```
mirror.cs.odu.edu        138     eclipse.mirror.rafal.ca   16
ftp2.osuosl.org          130     mirrors.xmission.com       6
mirror.umd.edu            28     mirrors.dotsrc.org         4
ca.mirrors.cicku.me        4     eclipse.c3sl.ufpr.br       2
```

for example:

```
[INFO] Downloaded from p2: https://eclipse.c3sl.ufpr.br/releases/2025-12/202512101000/plugins/com.google.guava.failureaccess_1.0.3.jar
```

The selection is per request, so the host set differs run to run and cannot be enumerated in advance — no allow list can be written for it. `-Declipse.p2.mirrors=false` ([Tycho system property](https://tycho.eclipseprojects.io/doc/main/SystemProperties.html); the older `-Dtycho.disableP2Mirrors=true` is deprecated) makes p2 read from the URL in the target definition, collapsing those eight hosts into the one the target already names.

## What this does not do

Two sources are untouched and remain follow ups:

| host | status |
|---|---|
| `repo.maven.apache.org` (2417 URLs) | to be routed through CFS (`vscjava` already has the Maven Central upstream) via `MavenAuthenticate@0` + a generated `settings.xml` mirror |
| `download.eclipse.org` | P2 — Azure Artifacts does not support the protocol, so this needs an SR21 exception |

There is also a third, less obvious one: `downloadJacocoAgent()` in this same script shells out to `curl https://repo1.maven.org/...`, which bypasses Maven configuration entirely and prints no URL, so it appears in no build log. It is left alone here because fixing it properly means fetching the agent through the authenticated feed, but it should not be forgotten when the pool policy is tightened.

## Verification

`npm run build-plugin` produces the same jars and the same `contributes.javaExtensions` list. The claim to check in CI is that `oss.sonatype.org` and every `mirror*` host disappear from the build log while the plugin still builds.
