### PR TITLE
fix(ci): upgrade @vscode/test-electron to fix macOS test failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "@types/vscode": "1.88.0",
                 "@typescript-eslint/eslint-plugin": "^5.60.1",
                 "@typescript-eslint/parser": "^5.60.1",
-                "@vscode/test-electron": "^2.5.2",
+                "@vscode/test-electron": "^3.1.0",
                 "eslint": "^8.43.0",
                 "glob": "^7.2.3",
                 "mocha": "^11.1.0",
@@ -728,9 +728,9 @@
             }
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-            "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+            "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -741,7 +741,7 @@
                 "semver": "^7.6.2"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=22"
             }
         },
         "node_modules/@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -562,7 +562,7 @@
         "@types/vscode": "1.88.0",
         "@typescript-eslint/eslint-plugin": "^5.60.1",
         "@typescript-eslint/parser": "^5.60.1",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.1.0",
         "eslint": "^8.43.0",
         "glob": "^7.2.3",
         "mocha": "^11.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
         "noImplicitReturns": true,
         "noUnusedParameters": true,
         "strictNullChecks": true,
-        "alwaysStrict": true
+        "alwaysStrict": true,
+        "skipLibCheck": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
## Problem

The macOS job fails on every run while Linux and Windows pass — see [run 30778812386](https://github.com/microsoft/vscode-java-test/actions/runs/30778812386/job/91579328110) (2026-08-03). It dies immediately after the VS Code download:

```
Test error: Error: spawn .../.vscode-test/vscode-darwin-arm64-1.131.0/Visual Studio Code.app/Contents/MacOS/Electron ENOENT
Error: Test run failed with code -2
```

## Root cause

VS Code 1.110 renamed the macOS main binary inside the `.app` bundle from the historical `Electron` to the product name (`Code`), keeping a compatibility symlink under the old name. That symlink was removed in microsoft/vscode#326502, so any 1.110+ archive now fails to launch via the old path. The test runner does not pin a VS Code version, so it resolves the latest release (1.131.0) and hits this.

`@vscode/test-electron` ^2.5.2 hardcodes the old path in `out/util.js`:

```js
return path.resolve(dir, 'Visual Studio Code.app/Contents/MacOS/Electron');
```

Only macOS goes through this code path, which is why the other platforms are unaffected. Upstream fixed it in microsoft/vscode-test#350, released in 3.1.0: the executable is resolved from `CFBundleExecutable` in `Info.plist`, falling back to the sole regular file in `Contents/MacOS/` and finally to the legacy `Electron` name, so both the new and pre-1.110 layouts work. The fix landed after 3.0.0, so 3.1.0 is the earliest release that carries it — there is no 2.x backport.

## Changes

Bump `@vscode/test-electron` `^2.5.2` → `^3.1.0`. `package.json` (+ lockfile) and one line in `tsconfig.json`.

Beyond `@vscode/test-electron` itself, the only lockfile churn is inside the `ora` dependency tree, which 3.x bumps from `^7` to `^8`.

### Why `skipLibCheck`

3.1.0 ships declarations using the generic `Buffer<ArrayBufferLike>`, which needs `@types/node` >= 22. This repo is on TypeScript 4.9 with older `@types/node`, so the upgrade alone fails to compile:

```
node_modules/@vscode/test-electron/out/util.d.ts(107,82): error TS2315: Type 'Buffer' is not generic.
```

Raising `@types/node` was tried first and is not viable — on vscode-java-test it kept the `Buffer` error *and* introduced unrelated breakage in `src/controller/utils.ts`. `skipLibCheck` is the standard remedy for third-party declaration mismatches, and sibling repos `vscode-java-dependency` and `vscode-spring-boot-dashboard` already enable it, so this also brings the repos in line with each other.

## On `engines.node`

3.x declares `engines.node >= 22` while CI runs Node 20, so `npm ci` emits:

```
npm warn EBADENGINE Unsupported engine
npm warn EBADENGINE   required: { node: '>=22' }
npm warn EBADENGINE   current: { node: 'v20.18.1' }
```

This is a warning, not an error — the install completes. Verified on Node 20.18.1 that 3.1.0 loads and resolves executable paths correctly; it uses no Node 22 only APIs and its transitive dependencies all accept `>=18`. A Node bump is therefore not needed to fix this and is deliberately left out to keep the change minimal.

## Verification

- `npm install` succeeds; installed version confirmed as 3.1.0.
- `tsc -p ./ --noEmit` passes.
- Executable resolution verified directly against `downloadDirToExecutablePath(..., "darwin-arm64")` with synthetic bundles: the new layout (`CFBundleExecutable=Code`) resolves to `Code`, and the legacy `Electron` layout still resolves to `Electron` — so the fix covers the failure without regressing older VS Code versions.

The real confirmation is the macOS job in this PR's own CI run.

## Related

Same fix applied across the affected Java extension repos: microsoft/vscode-gradle#1907 and the sibling PRs opened alongside this one.
