### PR TITLE
build: retry transient JDT LS p2 downloads

### DIFF
--- a/.azure-pipelines/vscode-java-test-ci.yml
+++ b/.azure-pipelines/vscode-java-test-ci.yml
@@ -58,6 +58,10 @@ extends:
                 displayName: npm run lint
               - script: npm run build-plugin
                 displayName: npm run build-plugin
+                # The JDT LS snapshot p2 site has no mirrors, and Tycho 4.0.5
+                # does not retry a direct connection reset. A task retry reuses
+                # the Maven/p2 cache and fetches only the missing artifact.
+                retryCountOnTaskFailure: 2
                 # System.AccessToken is a secret, and Azure Pipelines does not export secret
                 # variables to the environment -- not even through a variable that merely
                 # references one. It is mapped here, on the step that actually runs Maven,

--- a/.azure-pipelines/vscode-java-test-nightly.yml
+++ b/.azure-pipelines/vscode-java-test-nightly.yml
@@ -74,6 +74,10 @@ extends:
                 displayName: npm run lint
               - script: npm run build-plugin
                 displayName: npm run build-plugin
+                # The JDT LS snapshot p2 site has no mirrors, and Tycho 4.0.5
+                # does not retry a direct connection reset. A task retry reuses
+                # the Maven/p2 cache and fetches only the missing artifact.
+                retryCountOnTaskFailure: 2
                 # System.AccessToken is a secret, and Azure Pipelines does not export secret
                 # variables to the environment -- not even through a variable that merely
                 # references one. It is mapped here, on the step that actually runs Maven,

--- a/.azure-pipelines/vscode-java-test-rc.yml
+++ b/.azure-pipelines/vscode-java-test-rc.yml
@@ -69,6 +69,10 @@ extends:
                 displayName: npm run lint
               - script: npm run build-plugin
                 displayName: npm run build-plugin
+                # The JDT LS snapshot p2 site has no mirrors, and Tycho 4.0.5
+                # does not retry a direct connection reset. A task retry reuses
+                # the Maven/p2 cache and fetches only the missing artifact.
+                retryCountOnTaskFailure: 2
                 # System.AccessToken is a secret, and Azure Pipelines does not export secret
                 # variables to the environment -- not even through a variable that merely
                 # references one. It is mapped here, on the step that actually runs Maven,


### PR DESCRIPTION
## Why

Scheduled build [31864478](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31864478&view=results) failed while Tycho was downloading:

```
https://download.eclipse.org/jdtls/snapshots/repository/latest/plugins/org.gradle.toolingapi_8.9.0.v20250904-1000.jar
```

The server reset that connection. Tycho 4.0.5 then tried its local cache and failed the build because the artifact had not completed downloading.

This is not a Maven/CFS routing failure. A pre-CFS build, [31824861](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31824861&view=results), downloaded the same artifact from the same JDT LS snapshot URL successfully, and that repository's `artifacts.xml` does not define p2 mirrors. The failed build also restored its Maven artifacts from `vscjava` successfully before the p2 transfer failed.

## What changed

Set `retryCountOnTaskFailure: 2` on `npm run build-plugin` in the CI, nightly, and RC ADO pipelines.

Azure Pipelines retries the task on the same agent. Maven's local repository and Tycho's p2 cache therefore retain every completed download, so a retry only needs to fetch the missing artifact. This keeps transient network handling in the pipeline rather than adding retry code to the product or Node build script.

No runtime source, Maven resolution, target platform, or build output is changed.

## Verification

- Pipeline 15770 (nightly) preview: compiled, 0 errors
- Pipeline 15776 (RC) preview: compiled, 0 errors
- The manual hotfix run was canceled because this official pipeline requires approval for non-scheduled runs; it is not used as validation evidence.
- Runtime validation: pending the next scheduled run after merge. Scheduled runs do not require that manual approval.
