### PR TITLE
build: route test Maven imports through CFS

### DIFF
--- a/.azure-pipelines/maven-cfs-variables.yml
+++ b/.azure-pipelines/maven-cfs-variables.yml
@@ -30,15 +30,18 @@ variables:
   # MAVEN_ARGS to every invocation, so build scripts keep calling `mvnw` with no extra
   # flags of their own. Supported by Maven 3.9 and newer, which is what the wrapper here
   # pins.
-  - name: JAVA_TEST_MAVEN_USER_SETTINGS
-    value: $(Build.SourcesDirectory)/.azure-pipelines/cfs-settings.xml
-  - name: MAVEN_ARGS
-    value: -s $(JAVA_TEST_MAVEN_USER_SETTINGS)
-
+  #
   # Path two: plugin tests import sample Maven projects through JDT LS's embedded m2e.
-  # That Maven client runs inside the test JVM and does not read MAVEN_ARGS.
-  # AbstractProjectsManagerBasedTest maps JAVA_TEST_MAVEN_USER_SETTINGS to m2e's user
-  # settings before any project is imported.
+  # That Maven client runs inside Tycho's test JVM and does not read MAVEN_ARGS. Give
+  # the test JVM an isolated user.home whose .m2/settings.xml is prepared by
+  # maven-cfs.yml. m2e then discovers the CFS mirror through Maven's standard settings
+  # lookup, with no test or product source changes.
+  - name: JAVA_TEST_MAVEN_USER_HOME
+    value: $(Agent.TempDirectory)/java-test-maven-home-$(Build.BuildId)
+  - name: MAVEN_ARGS
+    value: >-
+      -s $(Build.SourcesDirectory)/.azure-pipelines/cfs-settings.xml
+      -Dtycho.testArgLine=-Duser.home=$(JAVA_TEST_MAVEN_USER_HOME)
 
   # Path three: the Maven distribution itself. The wrapper downloads it from
   # distributionUrl before Maven exists, so settings.xml cannot influence that request.

--- a/.azure-pipelines/maven-cfs-variables.yml
+++ b/.azure-pipelines/maven-cfs-variables.yml
@@ -18,7 +18,7 @@
 # steps that run Maven; grep for MVNW_PASSWORD to find them. That also keeps the token
 # out of the environment of every unrelated task in the job.
 #
-# Two independent egress paths have to be closed, and only the first is obvious.
+# Three independent egress paths have to be closed, and only the first is obvious.
 variables:
   # The feed's maven/v1 endpoint, read by cfs-settings.xml and by the wrapper below.
   # Committing it matches npm-cfs-variables.yml: a feed address is not a secret, and
@@ -26,13 +26,21 @@ variables:
   - name: CFS_MAVEN_URL
     value: https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/maven/v1
 
-  # Path one: artifact resolution. The `mvn` launcher prepends MAVEN_ARGS to every
-  # invocation, so build scripts keep calling `mvnw` with no extra flags of their own.
-  # Supported by Maven 3.9 and newer, which is what the wrapper here pins.
+  # Path one: artifact resolution by Maven itself. The `mvn` launcher prepends
+  # MAVEN_ARGS to every invocation, so build scripts keep calling `mvnw` with no extra
+  # flags of their own. Supported by Maven 3.9 and newer, which is what the wrapper here
+  # pins.
+  - name: JAVA_TEST_MAVEN_USER_SETTINGS
+    value: $(Build.SourcesDirectory)/.azure-pipelines/cfs-settings.xml
   - name: MAVEN_ARGS
-    value: -s $(Build.SourcesDirectory)/.azure-pipelines/cfs-settings.xml
+    value: -s $(JAVA_TEST_MAVEN_USER_SETTINGS)
 
-  # Path two: the Maven distribution itself. The wrapper downloads it from
+  # Path two: plugin tests import sample Maven projects through JDT LS's embedded m2e.
+  # That Maven client runs inside the test JVM and does not read MAVEN_ARGS.
+  # AbstractProjectsManagerBasedTest maps JAVA_TEST_MAVEN_USER_SETTINGS to m2e's user
+  # settings before any project is imported.
+
+  # Path three: the Maven distribution itself. The wrapper downloads it from
   # distributionUrl before Maven exists, so settings.xml cannot influence that request.
   # MVNW_REPOURL substitutes everything ahead of /org/apache/maven/ in that URL, which
   # is why .mvn/wrapper/maven-wrapper.properties still names the public host and needs

--- a/.azure-pipelines/maven-cfs.yml
+++ b/.azure-pipelines/maven-cfs.yml
@@ -1,0 +1,16 @@
+# Prepares Maven's standard user settings location for Maven clients running inside
+# the Tycho test JVM. The outer Maven process uses MAVEN_ARGS, but embedded m2e does
+# not see those command-line arguments and resolves settings from user.home instead.
+steps:
+  - task: PowerShell@2
+    displayName: Configure Maven test importer
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |-
+        $m2Directory = Join-Path '$(JAVA_TEST_MAVEN_USER_HOME)' '.m2'
+        New-Item -ItemType Directory -Path $m2Directory -Force | Out-Null
+        Copy-Item `
+          -LiteralPath '$(Build.SourcesDirectory)/.azure-pipelines/cfs-settings.xml' `
+          -Destination (Join-Path $m2Directory 'settings.xml') `
+          -Force

--- a/.azure-pipelines/vscode-java-test-ci.yml
+++ b/.azure-pipelines/vscode-java-test-ci.yml
@@ -56,6 +56,7 @@ extends:
                 displayName: npm install
               - script: npm run lint
                 displayName: npm run lint
+              - template: /.azure-pipelines/maven-cfs.yml@self
               - script: npm run build-plugin
                 displayName: npm run build-plugin
                 # System.AccessToken is a secret, and Azure Pipelines does not export secret

--- a/.azure-pipelines/vscode-java-test-nightly.yml
+++ b/.azure-pipelines/vscode-java-test-nightly.yml
@@ -72,6 +72,7 @@ extends:
                 displayName: npm install
               - script: npm run lint
                 displayName: npm run lint
+              - template: /.azure-pipelines/maven-cfs.yml@self
               - script: npm run build-plugin
                 displayName: npm run build-plugin
                 # System.AccessToken is a secret, and Azure Pipelines does not export secret

--- a/.azure-pipelines/vscode-java-test-rc.yml
+++ b/.azure-pipelines/vscode-java-test-rc.yml
@@ -67,6 +67,7 @@ extends:
                 displayName: npm install
               - script: npm run lint
                 displayName: npm run lint
+              - template: /.azure-pipelines/maven-cfs.yml@self
               - script: npm run build-plugin
                 displayName: npm run build-plugin
                 # System.AccessToken is a secret, and Azure Pipelines does not export secret

--- a/java-extension/com.microsoft.java.test.plugin.test/src/com/microsoft/java/test/plugin/AbstractProjectsManagerBasedTest.java
+++ b/java-extension/com.microsoft.java.test.plugin.test/src/com/microsoft/java/test/plugin/AbstractProjectsManagerBasedTest.java
@@ -48,7 +48,6 @@ import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.jdt.ls.core.internal.preferences.StandardPreferenceManager;
-import org.eclipse.m2e.core.MavenPlugin;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mock;
@@ -61,7 +60,6 @@ import org.mockito.Mockito;
 public abstract class AbstractProjectsManagerBasedTest {
 
 	public static final String TEST_PROJECT_NAME = "TestProject";
-	private static final String MAVEN_USER_SETTINGS_ENV = "JAVA_TEST_MAVEN_USER_SETTINGS";
 
 	protected StandardProjectsManager projectsManager;
 	@Mock
@@ -79,28 +77,10 @@ public abstract class AbstractProjectsManagerBasedTest {
 			preferenceManager = mock(StandardPreferenceManager.class);
 		}
 		initPreferenceManager(true);
-		configureMavenUserSettings(preferences);
 
 		oldPreferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
 		JavaLanguageServerPlugin.setPreferencesManager(preferenceManager);
 		projectsManager = new StandardProjectsManager(preferenceManager);
-	}
-
-	private void configureMavenUserSettings(Preferences preferences) throws CoreException, IOException {
-		String settingsPath = System.getenv(MAVEN_USER_SETTINGS_ENV);
-		if (StringUtils.isBlank(settingsPath)) {
-			return;
-		}
-
-		File settingsFile = new File(settingsPath);
-		if (!settingsFile.isFile()) {
-			throw new IOException("Maven user settings file does not exist: " + settingsPath);
-		}
-
-		String canonicalPath = settingsFile.getCanonicalPath();
-		preferences.setMavenUserSettings(canonicalPath);
-		// The preference manager is mocked in these tests, so apply the setting to m2e directly.
-		MavenPlugin.getMavenConfiguration().setUserSettingsFile(canonicalPath);
 	}
 
 	protected void initPreferences(Preferences preferences) throws IOException {

--- a/java-extension/com.microsoft.java.test.plugin.test/src/com/microsoft/java/test/plugin/AbstractProjectsManagerBasedTest.java
+++ b/java-extension/com.microsoft.java.test.plugin.test/src/com/microsoft/java/test/plugin/AbstractProjectsManagerBasedTest.java
@@ -48,6 +48,7 @@ import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.jdt.ls.core.internal.preferences.StandardPreferenceManager;
+import org.eclipse.m2e.core.MavenPlugin;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mock;
@@ -60,6 +61,7 @@ import org.mockito.Mockito;
 public abstract class AbstractProjectsManagerBasedTest {
 
 	public static final String TEST_PROJECT_NAME = "TestProject";
+	private static final String MAVEN_USER_SETTINGS_ENV = "JAVA_TEST_MAVEN_USER_SETTINGS";
 
 	protected StandardProjectsManager projectsManager;
 	@Mock
@@ -77,10 +79,28 @@ public abstract class AbstractProjectsManagerBasedTest {
 			preferenceManager = mock(StandardPreferenceManager.class);
 		}
 		initPreferenceManager(true);
+		configureMavenUserSettings(preferences);
 
 		oldPreferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
 		JavaLanguageServerPlugin.setPreferencesManager(preferenceManager);
 		projectsManager = new StandardProjectsManager(preferenceManager);
+	}
+
+	private void configureMavenUserSettings(Preferences preferences) throws CoreException, IOException {
+		String settingsPath = System.getenv(MAVEN_USER_SETTINGS_ENV);
+		if (StringUtils.isBlank(settingsPath)) {
+			return;
+		}
+
+		File settingsFile = new File(settingsPath);
+		if (!settingsFile.isFile()) {
+			throw new IOException("Maven user settings file does not exist: " + settingsPath);
+		}
+
+		String canonicalPath = settingsFile.getCanonicalPath();
+		preferences.setMavenUserSettings(canonicalPath);
+		// The preference manager is mocked in these tests, so apply the setting to m2e directly.
+		MavenPlugin.getMavenConfiguration().setUserSettingsFile(canonicalPath);
 	}
 
 	protected void initPreferences(Preferences preferences) throws IOException {


### PR DESCRIPTION
## Summary
- create an isolated Maven user home for the Tycho test JVM
- copy the existing CFS settings to its standard `.m2/settings.xml` location
- pass the temporary home through `tycho.testArgLine`, so embedded m2e uses Maven's native settings discovery
- keep product and test Java sources unchanged

## Why
The outer Maven build in scheduled run 31880346 used `vscjava`, but `CoverageHandlerTest` imported `coverage-test` through embedded m2e. That Maven client does not read the outer process's `MAVEN_ARGS` and made 10 requests to `repo.maven.apache.org`.

## Validation
- empty m2e local repository: 66/66 provenance records were `vscjava`
- full `clean verify`: 3 tests, 0 failures, `BUILD SUCCESS`

The next scheduled pre-release run will provide the final Network Isolation telemetry confirmation.